### PR TITLE
Added new y axis end stop holder to bg9/endstop_mount.scad as y_holde…

### DIFF
--- a/bg9/endstop_mount.scad
+++ b/bg9/endstop_mount.scad
@@ -223,3 +223,36 @@ module cap_cylinder(r=1, h=1, center=false){
 		}
 	}
 }
+
+module y_holder_switch(){
+    
+    width=22;
+    thick = 7;
+    wire = 5;
+    
+    switch_height=8;
+    
+    difference() {
+        union() {
+            translate([-wire/2-10,0,0])
+            difference() {
+            cube([20,width+2*wall,1],true);
+                cylinder(r=m3_rad+slop,h=2,center=true);
+            }
+            
+            translate([0,0,switch_height/2+wall/2]) cube([thick+wall*2, width+wall*2,switch_height+wall], center=true);
+        }
+        
+        difference(){
+            union(){
+                //endstop
+                translate([0,0,switch_height/2+wall]) cube([thick, width,switch_height+wall], center=true);
+                //wire pass
+                translate([-(thick-wire)/2,0,switch_height/2-.1]) cube([wire, width,switch_height], center=true);
+            }
+            
+            //retainer bump
+            translate([-thick/2-wall/5,0,switch_height*3/4]) scale([1,1,2]) sphere(r=wall/2);
+        }
+    }
+}

--- a/bg9/y_endstop_mount.stl
+++ b/bg9/y_endstop_mount.stl
@@ -1,0 +1,4734 @@
+solid OpenSCAD_Model
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 0.908473 5.82569
+      vertex -3.5 11 10
+      vertex -3.5 0.908473 6.17431
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.889014 6.37511
+      vertex -3.5 0.908473 6.17431
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.875202 6.51764
+      vertex -3.5 0.889014 6.37511
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.838039 6.70342
+      vertex -3.5 0.875202 6.51764
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.809671 6.84524
+      vertex -3.5 0.838039 6.70342
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.780235 6.93801
+      vertex -3.5 0.809671 6.84524
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.713872 7.14715
+      vertex -3.5 0.780235 6.93801
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.692819 7.1928
+      vertex -3.5 0.713872 7.14715
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.616436 7.34251
+      vertex -3.5 0.692819 7.1928
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.57985 7.41421
+      vertex -3.5 0.616436 7.34251
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.476701 7.55655
+      vertex -3.5 0.57985 7.41421
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.408073 7.6383
+      vertex -3.5 0.476701 7.55655
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.358134 7.67923
+      vertex -3.5 0.408073 7.6383
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.335639 7.69767
+      vertex -3.5 0.358134 7.67923
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.278325 7.73578
+      vertex -3.5 0.335639 7.69767
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.230939 7.76728
+      vertex -3.5 0.278325 7.73578
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.208334 7.77835
+      vertex -3.5 0.230939 7.76728
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.145588 7.80909
+      vertex -3.5 0.208334 7.77835
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.133838 7.81262
+      vertex -3.5 0.145588 7.80909
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.0748034 7.82378
+      vertex -3.5 0.133838 7.81262
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.07053 7.82459
+      vertex -3.5 0.0748034 7.82378
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.0658329 7.82489
+      vertex -3.5 0.07053 7.82459
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0 7.82908
+      vertex -3.5 0.0658329 7.82489
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 -11 10
+      vertex -3.5 0 7.82908
+      vertex -3.5 11 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 0 7.82908
+      vertex -3.5 -11 10
+      vertex -3.5 -0.0658329 7.82489
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.0658329 7.82489
+      vertex -3.5 -11 10
+      vertex -3.5 -0.07053 7.82459
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.07053 7.82459
+      vertex -3.5 -11 10
+      vertex -3.5 -0.0748034 7.82378
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.230939 7.76728
+      vertex -3.5 -0.335639 7.69767
+      vertex -3.5 -0.278325 7.73578
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.335639 7.69767
+      vertex -3.5 -0.408073 7.6383
+      vertex -3.5 -0.358134 7.67923
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 10
+      vertex -3.5 -0.780235 6.93801
+      vertex -3.5 -0.713872 7.14715
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 10
+      vertex -3.5 -0.889014 6.37511
+      vertex -3.5 -0.875202 6.51764
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.908473 6.17431
+      vertex -3.5 -11 10
+      vertex -3.5 -0.908473 5.82569
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.889014 6.37511
+      vertex -3.5 -11 10
+      vertex -3.5 -0.908473 6.17431
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.838039 6.70342
+      vertex -3.5 -11 10
+      vertex -3.5 -0.875202 6.51764
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.809671 6.84524
+      vertex -3.5 -11 10
+      vertex -3.5 -0.838039 6.70342
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.780235 6.93801
+      vertex -3.5 -11 10
+      vertex -3.5 -0.809671 6.84524
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.692819 7.1928
+      vertex -3.5 -11 10
+      vertex -3.5 -0.713872 7.14715
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.616436 7.34251
+      vertex -3.5 -11 10
+      vertex -3.5 -0.692819 7.1928
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.57985 7.41421
+      vertex -3.5 -11 10
+      vertex -3.5 -0.616436 7.34251
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.476701 7.55655
+      vertex -3.5 -11 10
+      vertex -3.5 -0.57985 7.41421
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.408073 7.6383
+      vertex -3.5 -11 10
+      vertex -3.5 -0.476701 7.55655
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.335639 7.69767
+      vertex -3.5 -11 10
+      vertex -3.5 -0.408073 7.6383
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.230939 7.76728
+      vertex -3.5 -11 10
+      vertex -3.5 -0.335639 7.69767
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.208334 7.77835
+      vertex -3.5 -11 10
+      vertex -3.5 -0.230939 7.76728
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.145588 7.80909
+      vertex -3.5 -11 10
+      vertex -3.5 -0.208334 7.77835
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.133838 7.81262
+      vertex -3.5 -11 10
+      vertex -3.5 -0.145588 7.80909
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.0748034 7.82378
+      vertex -3.5 -11 10
+      vertex -3.5 -0.133838 7.81262
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 0.889014 5.62489
+      vertex -3.5 11 10
+      vertex -3.5 0.908473 5.82569
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 11 10
+      vertex -3.5 0.889014 5.62489
+      vertex -3.5 11 0
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.875202 5.48236
+      vertex -3.5 11 0
+      vertex -3.5 0.889014 5.62489
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.838039 5.29658
+      vertex -3.5 11 0
+      vertex -3.5 0.875202 5.48236
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.809671 5.15476
+      vertex -3.5 11 0
+      vertex -3.5 0.838039 5.29658
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.780235 5.06199
+      vertex -3.5 11 0
+      vertex -3.5 0.809671 5.15476
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.713872 4.85285
+      vertex -3.5 11 0
+      vertex -3.5 0.780235 5.06199
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.692819 4.80719
+      vertex -3.5 11 0
+      vertex -3.5 0.713872 4.85285
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.616436 4.65749
+      vertex -3.5 11 0
+      vertex -3.5 0.692819 4.80719
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.57985 4.58579
+      vertex -3.5 11 0
+      vertex -3.5 0.616436 4.65749
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.476701 4.44345
+      vertex -3.5 11 0
+      vertex -3.5 0.57985 4.58579
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.408073 4.3617
+      vertex -3.5 11 0
+      vertex -3.5 0.476701 4.44345
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.358134 4.32076
+      vertex -3.5 11 0
+      vertex -3.5 0.408073 4.3617
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.335639 4.30233
+      vertex -3.5 11 0
+      vertex -3.5 0.358134 4.32076
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.278325 4.26422
+      vertex -3.5 11 0
+      vertex -3.5 0.335639 4.30233
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.230939 4.23272
+      vertex -3.5 11 0
+      vertex -3.5 0.278325 4.26422
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.208334 4.22165
+      vertex -3.5 11 0
+      vertex -3.5 0.230939 4.23272
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.145588 4.19091
+      vertex -3.5 11 0
+      vertex -3.5 0.208334 4.22165
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.133838 4.18738
+      vertex -3.5 11 0
+      vertex -3.5 0.145588 4.19091
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.0748034 4.17622
+      vertex -3.5 11 0
+      vertex -3.5 0.133838 4.18738
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.07053 4.17541
+      vertex -3.5 11 0
+      vertex -3.5 0.0748034 4.17622
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0.0658329 4.17511
+      vertex -3.5 11 0
+      vertex -3.5 0.07053 4.17541
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -3.5 0 4.17092
+      vertex -3.5 11 0
+      vertex -3.5 0.0658329 4.17511
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 0
+      vertex -3.5 0 4.17092
+      vertex -3.5 -0.0658329 4.17511
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 0
+      vertex -3.5 -0.0658329 4.17511
+      vertex -3.5 -0.07053 4.17541
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 0
+      vertex -3.5 -0.07053 4.17541
+      vertex -3.5 -0.0748034 4.17622
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 0
+      vertex -3.5 -0.0748034 4.17622
+      vertex -3.5 -0.133838 4.18738
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 0
+      vertex -3.5 -0.133838 4.18738
+      vertex -3.5 -0.145588 4.19091
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.335639 4.30233
+      vertex -3.5 -0.230939 4.23272
+      vertex -3.5 -0.278325 4.26422
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.408073 4.3617
+      vertex -3.5 -0.335639 4.30233
+      vertex -3.5 -0.358134 4.32076
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 0
+      vertex -3.5 -0.780235 5.06199
+      vertex -3.5 -0.809671 5.15476
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 10
+      vertex -3.5 -0.889014 5.62489
+      vertex -3.5 -0.908473 5.82569
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.889014 5.62489
+      vertex -3.5 -11 10
+      vertex -3.5 -0.875202 5.48236
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -11 0
+      vertex -3.5 -0.875202 5.48236
+      vertex -3.5 -11 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.875202 5.48236
+      vertex -3.5 -11 0
+      vertex -3.5 -0.838039 5.29658
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.838039 5.29658
+      vertex -3.5 -11 0
+      vertex -3.5 -0.809671 5.15476
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.780235 5.06199
+      vertex -3.5 -11 0
+      vertex -3.5 -0.713872 4.85285
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.713872 4.85285
+      vertex -3.5 -11 0
+      vertex -3.5 -0.692819 4.80719
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.692819 4.80719
+      vertex -3.5 -11 0
+      vertex -3.5 -0.616436 4.65749
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.616436 4.65749
+      vertex -3.5 -11 0
+      vertex -3.5 -0.57985 4.58579
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.57985 4.58579
+      vertex -3.5 -11 0
+      vertex -3.5 -0.476701 4.44345
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.476701 4.44345
+      vertex -3.5 -11 0
+      vertex -3.5 -0.408073 4.3617
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.408073 4.3617
+      vertex -3.5 -11 0
+      vertex -3.5 -0.335639 4.30233
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 0 4.17092
+      vertex -3.5 -11 0
+      vertex -3.5 11 0
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.208334 4.22165
+      vertex -3.5 -11 0
+      vertex -3.5 -0.145588 4.19091
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.230939 4.23272
+      vertex -3.5 -11 0
+      vertex -3.5 -0.208334 4.22165
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -3.5 -0.335639 4.30233
+      vertex -3.5 -11 0
+      vertex -3.5 -0.230939 4.23272
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 3.5 -11 1
+      vertex 3.5 11 10
+      vertex 3.5 11 1
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 3.5 11 10
+      vertex 3.5 -11 1
+      vertex 3.5 -11 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.5 11 10
+      vertex 1.5 11 1
+      vertex 3.5 11 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -3.5 11 0
+      vertex 1.5 11 1
+      vertex -3.5 11 10
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 1.5 11 1
+      vertex -3.5 11 0
+      vertex 1.5 11 0
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 3.5 11 10
+      vertex 1.5 11 1
+      vertex 3.5 11 1
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.5 11 1
+      vertex 3.5 -11 1
+      vertex 3.5 11 1
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.5 -11 1
+      vertex 1.5 11 1
+      vertex 1.5 -11 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.5 -11 1
+      vertex 3.5 -11 10
+      vertex 3.5 -11 1
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 3.5 -11 10
+      vertex 1.5 -11 1
+      vertex -3.5 -11 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.5 -11 0
+      vertex 1.5 -11 1
+      vertex 1.5 -11 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 1.5 -11 1
+      vertex -3.5 -11 0
+      vertex -3.5 -11 10
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 1.5 -11 0
+      vertex 1.5 11 1
+      vertex 1.5 11 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 1.5 11 1
+      vertex 1.5 -11 0
+      vertex 1.5 -11 1
+    endloop
+  endfacet
+  facet normal 0.928303 -0.248736 0.276376
+    outer loop
+      vertex -3.09329 -0.142243 7.14715
+      vertex -3.13025 -0.280166 7.14715
+      vertex -3.00746 -0.157378 6.84524
+    endloop
+  endfacet
+  facet normal 0.992374 0.0868239 0.0874906
+    outer loop
+      vertex -2.91894 0.172987 6.17431
+      vertex -2.93407 0 6.51764
+      vertex -2.9038 0 6.17431
+    endloop
+  endfacet
+  facet normal 0.415839 0.891772 0.178385
+    outer loop
+      vertex -3.5 0.838039 6.70342
+      vertex -3.5 0.809671 6.84524
+      vertex -3.44685 0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.421 0.902831 0.0874917
+    outer loop
+      vertex -3.5 0.908473 6.17431
+      vertex -3.5 0.889014 6.37511
+      vertex -3.4019 0.862729 6.17431
+    endloop
+  endfacet
+  facet normal 0.551234 -0.787247 0.276376
+    outer loop
+      vertex -3.31744 -0.694272 6.84524
+      vertex -3.49042 -0.709406 7.14715
+      vertex -3.44685 -0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.830607 0.222562 0.51045
+    outer loop
+      vertex -3.23554 0.241844 7.41421
+      vertex -3.36101 0.196175 7.6383
+      vertex -3.20364 0.122787 7.41421
+    endloop
+  endfacet
+  facet normal 0.704398 -0.704393 0.0874889
+    outer loop
+      vertex -3.16006 -0.620885 6.51764
+      vertex -3.25966 -0.763129 6.17431
+      vertex -3.13687 -0.640341 6.17431
+    endloop
+  endfacet
+  facet normal 0.695765 -0.695765 0.178385
+    outer loop
+      vertex -3.20573 -0.582563 6.84524
+      vertex -3.31744 -0.694272 6.84524
+      vertex -3.16006 -0.620885 6.51764
+    endloop
+  endfacet
+  facet normal 0.695763 0.695768 0.178383
+    outer loop
+      vertex -3.27911 0.739942 6.51764
+      vertex -3.31744 0.694272 6.84524
+      vertex -3.16006 0.620885 6.51764
+    endloop
+  endfacet
+  facet normal 0.957392 -0.0837597 -0.276377
+    outer loop
+      vertex -2.99369 0 5.15476
+      vertex -3.09329 -0.142243 4.85285
+      vertex -3.08085 0 4.85285
+    endloop
+  endfacet
+  facet normal 0.787247 -0.551234 -0.276375
+    outer loop
+      vertex -3.20573 -0.582563 5.15476
+      vertex -3.27249 -0.526541 4.85285
+      vertex -3.11511 -0.453154 5.15476
+    endloop
+  endfacet
+  facet normal 0.902832 0.420998 0.0874916
+    outer loop
+      vertex -2.96388 0.340718 6.17431
+      vertex -3.06348 0.482963 6.51764
+      vertex -2.99233 0.330365 6.51764
+    endloop
+  endfacet
+  facet normal 0.551237 0.787244 0.276377
+    outer loop
+      vertex -3.31744 0.694272 6.84524
+      vertex -3.49042 0.709406 7.14715
+      vertex -3.37346 0.627506 7.14715
+    endloop
+  endfacet
+  facet normal 0.704398 0.704393 0.0874889
+    outer loop
+      vertex -3.13687 0.640341 6.17431
+      vertex -3.25966 0.763129 6.17431
+      vertex -3.16006 0.620885 6.51764
+    endloop
+  endfacet
+  facet normal 0.571374 0.816013 0.0874919
+    outer loop
+      vertex -3.4019 0.862729 6.17431
+      vertex -3.41704 0.836515 6.51764
+      vertex -3.25966 0.763129 6.17431
+    endloop
+  endfacet
+  facet normal 0.806014 -0.564375 0.178385
+    outer loop
+      vertex -3.11511 -0.453154 6.84524
+      vertex -3.20573 -0.582563 6.84524
+      vertex -3.16006 -0.620885 6.51764
+    endloop
+  endfacet
+  facet normal 0.787247 0.551234 0.276375
+    outer loop
+      vertex -3.11511 0.453154 6.84524
+      vertex -3.27249 0.526541 7.14715
+      vertex -3.19059 0.409575 7.14715
+    endloop
+  endfacet
+  facet normal 0.950434 0.254664 -0.178384
+    outer loop
+      vertex -2.94875 0.16773 5.48236
+      vertex -3.00746 0.157378 5.15476
+      vertex -2.99233 0.330365 5.48236
+    endloop
+  endfacet
+  facet normal 0.755796 0.529212 0.385626
+    outer loop
+      vertex -3.27249 0.526541 7.14715
+      vertex -3.35832 0.454519 7.41421
+      vertex -3.19059 0.409575 7.14715
+    endloop
+  endfacet
+  facet normal 0.731364 -0.195967 0.653226
+    outer loop
+      vertex -3.33514 -0.0995998 7.6383
+      vertex -3.4838 -0.0733862 7.81262
+      vertex -3.36101 -0.196175 7.6383
+    endloop
+  endfacet
+  facet normal 0.755796 -0.529212 -0.385626
+    outer loop
+      vertex -3.27249 -0.526541 4.85285
+      vertex -3.35832 -0.454519 4.58579
+      vertex -3.19059 -0.409575 4.85285
+    endloop
+  endfacet
+  facet normal 0.962223 0.257823 0.0874913
+    outer loop
+      vertex -2.96388 0.340718 6.17431
+      vertex -2.99233 0.330365 6.51764
+      vertex -2.91894 0.172987 6.17431
+    endloop
+  endfacet
+  facet normal 0.992374 0.0868253 0.0874913
+    outer loop
+      vertex -2.91894 0.172987 6.17431
+      vertex -2.94875 0.16773 6.51764
+      vertex -2.93407 0 6.51764
+    endloop
+  endfacet
+  facet normal 0.787247 0.551234 -0.276375
+    outer loop
+      vertex -3.11511 0.453154 5.15476
+      vertex -3.27249 0.526541 4.85285
+      vertex -3.20573 0.582563 5.15476
+    endloop
+  endfacet
+  facet normal 0.906307 0.422621 0
+    outer loop
+      vertex -2.96388 0.340718 6.17431
+      vertex -3.03727 0.498096 5.82569
+      vertex -3.03727 0.498096 6.17431
+    endloop
+  endfacet
+  facet normal 0.906307 0.422621 0
+    outer loop
+      vertex -3.03727 0.498096 5.82569
+      vertex -2.96388 0.340718 6.17431
+      vertex -2.96388 0.340718 5.82569
+    endloop
+  endfacet
+  facet normal 0.571374 0.816013 -0.0874919
+    outer loop
+      vertex -3.25966 0.763129 5.82569
+      vertex -3.41704 0.836515 5.48236
+      vertex -3.4019 0.862729 5.82569
+    endloop
+  endfacet
+  facet normal 0.836209 -0.389931 0.385627
+    outer loop
+      vertex -3.23554 -0.241844 7.41421
+      vertex -3.28763 -0.353553 7.41421
+      vertex -3.19059 -0.409575 7.14715
+    endloop
+  endfacet
+  facet normal 0.779342 -0.363411 0.510449
+    outer loop
+      vertex -3.36101 -0.196175 7.6383
+      vertex -3.40327 -0.286788 7.6383
+      vertex -3.23554 -0.241844 7.41421
+    endloop
+  endfacet
+  facet normal 0.779341 0.363413 0.510449
+    outer loop
+      vertex -3.28763 0.353553 7.41421
+      vertex -3.40327 0.286788 7.6383
+      vertex -3.23554 0.241844 7.41421
+    endloop
+  endfacet
+  facet normal 0.830607 -0.222559 0.510451
+    outer loop
+      vertex -3.33514 -0.0995998 7.6383
+      vertex -3.36101 -0.196175 7.6383
+      vertex -3.20364 -0.122787 7.41421
+    endloop
+  endfacet
+  facet normal 0.928303 0.248736 0.276376
+    outer loop
+      vertex -3.04835 0.309975 6.84524
+      vertex -3.13025 0.280166 7.14715
+      vertex -3.00746 0.157378 6.84524
+    endloop
+  endfacet
+  facet normal 0.957392 0.0837631 0.276376
+    outer loop
+      vertex -3.00746 0.157378 6.84524
+      vertex -3.09329 0.142243 7.14715
+      vertex -2.99369 0 6.84524
+    endloop
+  endfacet
+  facet normal 0.679561 0.679568 -0.276377
+    outer loop
+      vertex -3.27249 0.526541 4.85285
+      vertex -3.37346 0.627506 4.85285
+      vertex -3.31744 0.694272 5.15476
+    endloop
+  endfacet
+  facet normal 0.962223 -0.257823 -0.0874913
+    outer loop
+      vertex -2.96388 -0.340718 5.82569
+      vertex -2.99233 -0.330365 5.48236
+      vertex -2.91894 -0.172987 5.82569
+    endloop
+  endfacet
+  facet normal 0.962223 0.257823 -0.0874916
+    outer loop
+      vertex -2.94875 0.16773 5.48236
+      vertex -2.99233 0.330365 5.48236
+      vertex -2.91894 0.172987 5.82569
+    endloop
+  endfacet
+  facet normal 0.421 0.902831 -0.0874918
+    outer loop
+      vertex -3.41704 0.836515 5.48236
+      vertex -3.5 0.889014 5.62489
+      vertex -3.4019 0.862729 5.82569
+    endloop
+  endfacet
+  facet normal 0.421 0.902831 -0.0874916
+    outer loop
+      vertex -3.5 0.889014 5.62489
+      vertex -3.41704 0.836515 5.48236
+      vertex -3.5 0.875202 5.48236
+    endloop
+  endfacet
+  facet normal 0.695765 -0.695765 -0.178385
+    outer loop
+      vertex -3.16006 -0.620885 5.48236
+      vertex -3.31744 -0.694272 5.15476
+      vertex -3.20573 -0.582563 5.15476
+    endloop
+  endfacet
+  facet normal 0.816012 -0.571375 -0.0874904
+    outer loop
+      vertex -3.03727 -0.498096 5.82569
+      vertex -3.16006 -0.620885 5.48236
+      vertex -3.06348 -0.482963 5.48236
+    endloop
+  endfacet
+  facet normal 0.415843 -0.89177 -0.178383
+    outer loop
+      vertex -3.5 -0.838039 5.29658
+      vertex -3.41704 -0.836515 5.48236
+      vertex -3.5 -0.875202 5.48236
+    endloop
+  endfacet
+  facet normal 0.415842 -0.891771 -0.178383
+    outer loop
+      vertex -3.41704 -0.836515 5.48236
+      vertex -3.5 -0.838039 5.29658
+      vertex -3.44685 -0.784885 5.15476
+    endloop
+  endfacet
+  facet normal 0.679565 -0.679565 -0.276375
+    outer loop
+      vertex -3.20573 -0.582563 5.15476
+      vertex -3.31744 -0.694272 5.15476
+      vertex -3.27249 -0.526541 4.85285
+    endloop
+  endfacet
+  facet normal 0.564375 -0.806015 -0.178383
+    outer loop
+      vertex -3.27911 -0.739942 5.48236
+      vertex -3.44685 -0.784885 5.15476
+      vertex -3.31744 -0.694272 5.15476
+    endloop
+  endfacet
+  facet normal 0.992374 -0.0868253 -0.0874913
+    outer loop
+      vertex -2.91894 -0.172987 5.82569
+      vertex -2.94875 -0.16773 5.48236
+      vertex -2.93407 0 5.48236
+    endloop
+  endfacet
+  facet normal 0.856637 0.0749438 0.510447
+    outer loop
+      vertex -3.20364 0.122787 7.41421
+      vertex -3.32642 0 7.6383
+      vertex -3.19289 0 7.41421
+    endloop
+  endfacet
+  facet normal 0.89177 -0.415842 0.178385
+    outer loop
+      vertex -3.04835 -0.309975 6.84524
+      vertex -3.11511 -0.453154 6.84524
+      vertex -3.06348 -0.482963 6.51764
+    endloop
+  endfacet
+  facet normal 0.950434 -0.254666 0.178385
+    outer loop
+      vertex -3.00746 -0.157378 6.84524
+      vertex -3.04835 -0.309975 6.84524
+      vertex -2.99233 -0.330365 6.51764
+    endloop
+  endfacet
+  facet normal 0.950434 0.254664 0.178384
+    outer loop
+      vertex -2.99233 0.330365 6.51764
+      vertex -3.00746 0.157378 6.84524
+      vertex -2.94875 0.16773 6.51764
+    endloop
+  endfacet
+  facet normal 0.962223 -0.257823 -0.0874916
+    outer loop
+      vertex -2.91894 -0.172987 5.82569
+      vertex -2.99233 -0.330365 5.48236
+      vertex -2.94875 -0.16773 5.48236
+    endloop
+  endfacet
+  facet normal 0.836209 -0.38993 -0.385627
+    outer loop
+      vertex -3.19059 -0.409575 4.85285
+      vertex -3.23554 -0.241844 4.58579
+      vertex -3.13025 -0.280166 4.85285
+    endloop
+  endfacet
+  facet normal 0.871006 0.406159 -0.276375
+    outer loop
+      vertex -3.04835 0.309975 5.15476
+      vertex -3.19059 0.409575 4.85285
+      vertex -3.11511 0.453154 5.15476
+    endloop
+  endfacet
+  facet normal 0.695765 0.695765 -0.178385
+    outer loop
+      vertex -3.20573 0.582563 5.15476
+      vertex -3.31744 0.694272 5.15476
+      vertex -3.16006 0.620885 5.48236
+    endloop
+  endfacet
+  facet normal 0.891217 -0.238799 0.385625
+    outer loop
+      vertex -3.09329 -0.142243 7.14715
+      vertex -3.20364 -0.122787 7.41421
+      vertex -3.13025 -0.280166 7.14715
+    endloop
+  endfacet
+  facet normal 0.754281 0.0659973 0.653226
+    outer loop
+      vertex -3.33514 0.0995998 7.6383
+      vertex -3.4838 0.0733862 7.81262
+      vertex -3.32642 0 7.6383
+    endloop
+  endfacet
+  facet normal 0.75428 -0.0659876 0.653229
+    outer loop
+      vertex -3.47738 0 7.81262
+      vertex -3.4838 -0.0733862 7.81262
+      vertex -3.32642 0 7.6383
+    endloop
+  endfacet
+  facet normal 0.686224 -0.319986 0.653227
+    outer loop
+      vertex -3.5 -0.145588 7.80909
+      vertex -3.5 -0.208334 7.77835
+      vertex -3.36101 -0.196175 7.6383
+    endloop
+  endfacet
+  facet normal 0.535386 0.535405 0.653225
+    outer loop
+      vertex -3.5 0.358134 7.67923
+      vertex -3.5 0.335639 7.69767
+      vertex -3.46061 0.368688 7.6383
+    endloop
+  endfacet
+  facet normal 0.806014 0.564375 0.178385
+    outer loop
+      vertex -3.16006 0.620885 6.51764
+      vertex -3.20573 0.582563 6.84524
+      vertex -3.11511 0.453154 6.84524
+    endloop
+  endfacet
+  facet normal 0.856634 0.0749528 0.510451
+    outer loop
+      vertex -3.20364 0.122787 7.41421
+      vertex -3.33514 0.0995998 7.6383
+      vertex -3.32642 0 7.6383
+    endloop
+  endfacet
+  facet normal 0.75428 0.0659876 0.653229
+    outer loop
+      vertex -3.32642 0 7.6383
+      vertex -3.4838 0.0733862 7.81262
+      vertex -3.47738 0 7.81262
+    endloop
+  endfacet
+  facet normal 0.535391 0.535398 0.653228
+    outer loop
+      vertex -3.5 0.408073 7.6383
+      vertex -3.5 0.358134 7.67923
+      vertex -3.46061 0.368688 7.6383
+    endloop
+  endfacet
+  facet normal 0.755797 0.52921 0.385627
+    outer loop
+      vertex -3.19059 0.409575 7.14715
+      vertex -3.35832 0.454519 7.41421
+      vertex -3.28763 0.353553 7.41421
+    endloop
+  endfacet
+  facet normal 0.695765 0.695765 0.178385
+    outer loop
+      vertex -3.16006 0.620885 6.51764
+      vertex -3.31744 0.694272 6.84524
+      vertex -3.20573 0.582563 6.84524
+    endloop
+  endfacet
+  facet normal 0.551234 0.787247 0.276376
+    outer loop
+      vertex -3.44685 0.784885 6.84524
+      vertex -3.49042 0.709406 7.14715
+      vertex -3.31744 0.694272 6.84524
+    endloop
+  endfacet
+  facet normal 0.806015 0.564375 0.178385
+    outer loop
+      vertex -3.06348 0.482963 6.51764
+      vertex -3.16006 0.620885 6.51764
+      vertex -3.11511 0.453154 6.84524
+    endloop
+  endfacet
+  facet normal 0.806014 0.564375 -0.178385
+    outer loop
+      vertex -3.11511 0.453154 5.15476
+      vertex -3.20573 0.582563 5.15476
+      vertex -3.16006 0.620885 5.48236
+    endloop
+  endfacet
+  facet normal 0.587748 -0.0514187 -0.807409
+    outer loop
+      vertex -3.5 -0.0658329 4.17511
+      vertex -3.47738 0 4.18738
+      vertex -3.4838 -0.0733862 4.18738
+    endloop
+  endfacet
+  facet normal 0.587745 -0.0514173 -0.807411
+    outer loop
+      vertex -3.47738 0 4.18738
+      vertex -3.5 -0.0658329 4.17511
+      vertex -3.5 0 4.17092
+    endloop
+  endfacet
+  facet normal 0.992374 -0.0868239 -0.0874906
+    outer loop
+      vertex -2.91894 -0.172987 5.82569
+      vertex -2.93407 0 5.48236
+      vertex -2.9038 0 5.82569
+    endloop
+  endfacet
+  facet normal 0.89177 0.415842 -0.178385
+    outer loop
+      vertex -3.04835 0.309975 5.15476
+      vertex -3.11511 0.453154 5.15476
+      vertex -3.06348 0.482963 5.48236
+    endloop
+  endfacet
+  facet normal 0.608042 0.608051 -0.51045
+    outer loop
+      vertex -3.46061 0.368688 4.3617
+      vertex -3.5 0.476701 4.44345
+      vertex -3.44548 0.541675 4.58579
+    endloop
+  endfacet
+  facet normal 0.608043 0.608051 -0.510449
+    outer loop
+      vertex -3.5 0.476701 4.44345
+      vertex -3.46061 0.368688 4.3617
+      vertex -3.5 0.408073 4.3617
+    endloop
+  endfacet
+  facet normal 0.754281 0.0659973 -0.653226
+    outer loop
+      vertex -3.32642 0 4.3617
+      vertex -3.4838 0.0733862 4.18738
+      vertex -3.33514 0.0995998 4.3617
+    endloop
+  endfacet
+  facet normal 0.421 0.902831 0.0874916
+    outer loop
+      vertex -3.41704 0.836515 6.51764
+      vertex -3.5 0.889014 6.37511
+      vertex -3.5 0.875202 6.51764
+    endloop
+  endfacet
+  facet normal 0.421 0.902831 0.0874918
+    outer loop
+      vertex -3.5 0.889014 6.37511
+      vertex -3.41704 0.836515 6.51764
+      vertex -3.4019 0.862729 6.17431
+    endloop
+  endfacet
+  facet normal 0.422621 -0.906307 0
+    outer loop
+      vertex -3.5 -0.908473 5.82569
+      vertex -3.4019 -0.862729 6.17431
+      vertex -3.5 -0.908473 6.17431
+    endloop
+  endfacet
+  facet normal 0.422621 -0.906307 0
+    outer loop
+      vertex -3.4019 -0.862729 6.17431
+      vertex -3.5 -0.908473 5.82569
+      vertex -3.4019 -0.862729 5.82569
+    endloop
+  endfacet
+  facet normal 0.70711 -0.707104 0
+    outer loop
+      vertex -3.25966 -0.763129 6.17431
+      vertex -3.13687 -0.640341 5.82569
+      vertex -3.13687 -0.640341 6.17431
+    endloop
+  endfacet
+  facet normal 0.70711 -0.707104 0
+    outer loop
+      vertex -3.13687 -0.640341 5.82569
+      vertex -3.25966 -0.763129 6.17431
+      vertex -3.25966 -0.763129 5.82569
+    endloop
+  endfacet
+  facet normal 0.421 -0.902831 0.0874917
+    outer loop
+      vertex -3.5 -0.889014 6.37511
+      vertex -3.5 -0.908473 6.17431
+      vertex -3.4019 -0.862729 6.17431
+    endloop
+  endfacet
+  facet normal 0.89177 -0.415842 -0.178385
+    outer loop
+      vertex -3.06348 -0.482963 5.48236
+      vertex -3.11511 -0.453154 5.15476
+      vertex -3.04835 -0.309975 5.15476
+    endloop
+  endfacet
+  facet normal 0.406154 -0.871008 -0.276376
+    outer loop
+      vertex -3.49042 -0.709406 4.85285
+      vertex -3.5 -0.780235 5.06199
+      vertex -3.5 -0.713872 4.85285
+    endloop
+  endfacet
+  facet normal 0.406156 -0.871007 -0.276376
+    outer loop
+      vertex -3.5 -0.780235 5.06199
+      vertex -3.49042 -0.709406 4.85285
+      vertex -3.44685 -0.784885 5.15476
+    endloop
+  endfacet
+  facet normal 0.755796 -0.529212 0.385626
+    outer loop
+      vertex -3.19059 -0.409575 7.14715
+      vertex -3.35832 -0.454519 7.41421
+      vertex -3.27249 -0.526541 7.14715
+    endloop
+  endfacet
+  facet normal 0.787247 -0.551234 0.276375
+    outer loop
+      vertex -3.19059 -0.409575 7.14715
+      vertex -3.27249 -0.526541 7.14715
+      vertex -3.11511 -0.453154 6.84524
+    endloop
+  endfacet
+  facet normal 0.571374 -0.816013 0.0874919
+    outer loop
+      vertex -3.25966 -0.763129 6.17431
+      vertex -3.41704 -0.836515 6.51764
+      vertex -3.4019 -0.862729 6.17431
+    endloop
+  endfacet
+  facet normal 0.81601 -0.571378 0.0874889
+    outer loop
+      vertex -3.03727 -0.498096 6.17431
+      vertex -3.16006 -0.620885 6.51764
+      vertex -3.13687 -0.640341 6.17431
+    endloop
+  endfacet
+  facet normal 0.871006 -0.406159 0.276375
+    outer loop
+      vertex -3.04835 -0.309975 6.84524
+      vertex -3.19059 -0.409575 7.14715
+      vertex -3.11511 -0.453154 6.84524
+    endloop
+  endfacet
+  facet normal 0.950434 -0.254664 0.178384
+    outer loop
+      vertex -2.94875 -0.16773 6.51764
+      vertex -3.00746 -0.157378 6.84524
+      vertex -2.99233 -0.330365 6.51764
+    endloop
+  endfacet
+  facet normal 0.980216 0.0857615 0.178384
+    outer loop
+      vertex -2.94875 0.16773 6.51764
+      vertex -3.00746 0.157378 6.84524
+      vertex -2.93407 0 6.51764
+    endloop
+  endfacet
+  facet normal 0.891216 0.238802 0.385627
+    outer loop
+      vertex -3.13025 0.280166 7.14715
+      vertex -3.23554 0.241844 7.41421
+      vertex -3.20364 0.122787 7.41421
+    endloop
+  endfacet
+  facet normal 0.962223 0.257823 0.0874916
+    outer loop
+      vertex -2.91894 0.172987 6.17431
+      vertex -2.99233 0.330365 6.51764
+      vertex -2.94875 0.16773 6.51764
+    endloop
+  endfacet
+  facet normal 0.695763 -0.695768 -0.178383
+    outer loop
+      vertex -3.27911 -0.739942 5.48236
+      vertex -3.31744 -0.694272 5.15476
+      vertex -3.16006 -0.620885 5.48236
+    endloop
+  endfacet
+  facet normal 0.81601 -0.571378 -0.0874889
+    outer loop
+      vertex -3.13687 -0.640341 5.82569
+      vertex -3.16006 -0.620885 5.48236
+      vertex -3.03727 -0.498096 5.82569
+    endloop
+  endfacet
+  facet normal 0.871007 -0.406157 -0.276376
+    outer loop
+      vertex -3.04835 -0.309975 5.15476
+      vertex -3.19059 -0.409575 4.85285
+      vertex -3.13025 -0.280166 4.85285
+    endloop
+  endfacet
+  facet normal 0.871006 -0.406159 -0.276375
+    outer loop
+      vertex -3.11511 -0.453154 5.15476
+      vertex -3.19059 -0.409575 4.85285
+      vertex -3.04835 -0.309975 5.15476
+    endloop
+  endfacet
+  facet normal 0.980216 -0.0857615 0.178384
+    outer loop
+      vertex -2.93407 0 6.51764
+      vertex -3.00746 -0.157378 6.84524
+      vertex -2.94875 -0.16773 6.51764
+    endloop
+  endfacet
+  facet normal 0.992374 -0.0868253 0.0874913
+    outer loop
+      vertex -2.93407 0 6.51764
+      vertex -2.94875 -0.16773 6.51764
+      vertex -2.91894 -0.172987 6.17431
+    endloop
+  endfacet
+  facet normal 0.787247 -0.551234 -0.276375
+    outer loop
+      vertex -3.11511 -0.453154 5.15476
+      vertex -3.27249 -0.526541 4.85285
+      vertex -3.19059 -0.409575 4.85285
+    endloop
+  endfacet
+  facet normal 0.957392 0.0837631 -0.276376
+    outer loop
+      vertex -2.99369 0 5.15476
+      vertex -3.09329 0.142243 4.85285
+      vertex -3.00746 0.157378 5.15476
+    endloop
+  endfacet
+  facet normal 0.950434 -0.254664 -0.178384
+    outer loop
+      vertex -2.99233 -0.330365 5.48236
+      vertex -3.00746 -0.157378 5.15476
+      vertex -2.94875 -0.16773 5.48236
+    endloop
+  endfacet
+  facet normal 0.950434 -0.254666 -0.178385
+    outer loop
+      vertex -2.99233 -0.330365 5.48236
+      vertex -3.04835 -0.309975 5.15476
+      vertex -3.00746 -0.157378 5.15476
+    endloop
+  endfacet
+  facet normal 0.731362 -0.19597 -0.653227
+    outer loop
+      vertex -3.36101 -0.196175 4.3617
+      vertex -3.5 -0.133838 4.18738
+      vertex -3.4838 -0.0733862 4.18738
+    endloop
+  endfacet
+  facet normal 0.731358 -0.195984 -0.653228
+    outer loop
+      vertex -3.5 -0.133838 4.18738
+      vertex -3.36101 -0.196175 4.3617
+      vertex -3.5 -0.145588 4.19091
+    endloop
+  endfacet
+  facet normal 0.891217 -0.238799 -0.385625
+    outer loop
+      vertex -3.13025 -0.280166 4.85285
+      vertex -3.20364 -0.122787 4.58579
+      vertex -3.09329 -0.142243 4.85285
+    endloop
+  endfacet
+  facet normal 0.551234 0.787247 -0.276376
+    outer loop
+      vertex -3.31744 0.694272 5.15476
+      vertex -3.49042 0.709406 4.85285
+      vertex -3.44685 0.784885 5.15476
+    endloop
+  endfacet
+  facet normal 0.830607 -0.222562 0.51045
+    outer loop
+      vertex -3.20364 -0.122787 7.41421
+      vertex -3.36101 -0.196175 7.6383
+      vertex -3.23554 -0.241844 7.41421
+    endloop
+  endfacet
+  facet normal 0.754281 -0.0659973 0.653226
+    outer loop
+      vertex -3.32642 0 7.6383
+      vertex -3.4838 -0.0733862 7.81262
+      vertex -3.33514 -0.0995998 7.6383
+    endloop
+  endfacet
+  facet normal 0.686224 0.319986 0.653227
+    outer loop
+      vertex -3.5 0.208334 7.77835
+      vertex -3.5 0.145588 7.80909
+      vertex -3.36101 0.196175 7.6383
+    endloop
+  endfacet
+  facet normal 0.569892 0.152708 0.807405
+    outer loop
+      vertex -3.5 0.0748034 7.82378
+      vertex -3.5 0.07053 7.82459
+      vertex -3.4838 0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.679561 0.679568 0.276377
+    outer loop
+      vertex -3.31744 0.694272 6.84524
+      vertex -3.37346 0.627506 7.14715
+      vertex -3.27249 0.526541 7.14715
+    endloop
+  endfacet
+  facet normal 0.620233 0.434289 0.653226
+    outer loop
+      vertex -3.5 0.335639 7.69767
+      vertex -3.40327 0.286788 7.6383
+      vertex -3.46061 0.368688 7.6383
+    endloop
+  endfacet
+  facet normal 0.620233 0.434285 0.653228
+    outer loop
+      vertex -3.40327 0.286788 7.6383
+      vertex -3.5 0.335639 7.69767
+      vertex -3.5 0.278325 7.73578
+    endloop
+  endfacet
+  facet normal 0.608043 0.60805 0.510449
+    outer loop
+      vertex -3.44548 0.541675 7.41421
+      vertex -3.46061 0.368688 7.6383
+      vertex -3.35832 0.454519 7.41421
+    endloop
+  endfacet
+  facet normal 0.891217 0.238799 0.385625
+    outer loop
+      vertex -3.13025 0.280166 7.14715
+      vertex -3.20364 0.122787 7.41421
+      vertex -3.09329 0.142243 7.14715
+    endloop
+  endfacet
+  facet normal 0.569892 -0.152708 0.807405
+    outer loop
+      vertex -3.5 -0.07053 7.82459
+      vertex -3.5 -0.0748034 7.82378
+      vertex -3.4838 -0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.529215 0.755794 0.385625
+    outer loop
+      vertex -3.37346 0.627506 7.14715
+      vertex -3.5 0.692819 7.1928
+      vertex -3.5 0.616436 7.34251
+    endloop
+  endfacet
+  facet normal 0.529215 0.755795 0.385624
+    outer loop
+      vertex -3.5 0.692819 7.1928
+      vertex -3.37346 0.627506 7.14715
+      vertex -3.49042 0.709406 7.14715
+    endloop
+  endfacet
+  facet normal 0.704392 0.704398 0.0874928
+    outer loop
+      vertex -3.25966 0.763129 6.17431
+      vertex -3.27911 0.739942 6.51764
+      vertex -3.16006 0.620885 6.51764
+    endloop
+  endfacet
+  facet normal 0.571375 0.816012 0.0874927
+    outer loop
+      vertex -3.25966 0.763129 6.17431
+      vertex -3.41704 0.836515 6.51764
+      vertex -3.27911 0.739942 6.51764
+    endloop
+  endfacet
+  facet normal 0.81601 0.571378 0.0874889
+    outer loop
+      vertex -3.13687 0.640341 6.17431
+      vertex -3.16006 0.620885 6.51764
+      vertex -3.03727 0.498096 6.17431
+    endloop
+  endfacet
+  facet normal 0.950434 0.254666 0.178385
+    outer loop
+      vertex -2.99233 0.330365 6.51764
+      vertex -3.04835 0.309975 6.84524
+      vertex -3.00746 0.157378 6.84524
+    endloop
+  endfacet
+  facet normal 0.902831 0.421 0.0874906
+    outer loop
+      vertex -3.03727 0.498096 6.17431
+      vertex -3.06348 0.482963 6.51764
+      vertex -2.96388 0.340718 6.17431
+    endloop
+  endfacet
+  facet normal 0.806015 0.564375 -0.178385
+    outer loop
+      vertex -3.11511 0.453154 5.15476
+      vertex -3.16006 0.620885 5.48236
+      vertex -3.06348 0.482963 5.48236
+    endloop
+  endfacet
+  facet normal 0.950434 0.254666 -0.178385
+    outer loop
+      vertex -3.00746 0.157378 5.15476
+      vertex -3.04835 0.309975 5.15476
+      vertex -2.99233 0.330365 5.48236
+    endloop
+  endfacet
+  facet normal 0.679565 0.679565 -0.276375
+    outer loop
+      vertex -3.27249 0.526541 4.85285
+      vertex -3.31744 0.694272 5.15476
+      vertex -3.20573 0.582563 5.15476
+    endloop
+  endfacet
+  facet normal 0.564375 0.806015 -0.178383
+    outer loop
+      vertex -3.27911 0.739942 5.48236
+      vertex -3.44685 0.784885 5.15476
+      vertex -3.41704 0.836515 5.48236
+    endloop
+  endfacet
+  facet normal 0.996194 0.0871581 0
+    outer loop
+      vertex -2.9038 0 6.17431
+      vertex -2.91894 0.172987 5.82569
+      vertex -2.91894 0.172987 6.17431
+    endloop
+  endfacet
+  facet normal 0.996194 0.0871581 0
+    outer loop
+      vertex -2.91894 0.172987 5.82569
+      vertex -2.9038 0 6.17431
+      vertex -2.9038 0 5.82569
+    endloop
+  endfacet
+  facet normal 0.992374 0.0868239 -0.0874906
+    outer loop
+      vertex -2.9038 0 5.82569
+      vertex -2.93407 0 5.48236
+      vertex -2.91894 0.172987 5.82569
+    endloop
+  endfacet
+  facet normal 0.996194 -0.0871581 0
+    outer loop
+      vertex -2.91894 -0.172987 6.17431
+      vertex -2.9038 0 5.82569
+      vertex -2.9038 0 6.17431
+    endloop
+  endfacet
+  facet normal 0.996194 -0.0871581 0
+    outer loop
+      vertex -2.9038 0 5.82569
+      vertex -2.91894 -0.172987 6.17431
+      vertex -2.91894 -0.172987 5.82569
+    endloop
+  endfacet
+  facet normal 0.573574 0.819154 -0
+    outer loop
+      vertex -3.25966 0.763129 5.82569
+      vertex -3.4019 0.862729 6.17431
+      vertex -3.25966 0.763129 6.17431
+    endloop
+  endfacet
+  facet normal 0.573574 0.819154 0
+    outer loop
+      vertex -3.4019 0.862729 6.17431
+      vertex -3.25966 0.763129 5.82569
+      vertex -3.4019 0.862729 5.82569
+    endloop
+  endfacet
+  facet normal 0.70711 0.707104 0
+    outer loop
+      vertex -3.13687 0.640341 6.17431
+      vertex -3.25966 0.763129 5.82569
+      vertex -3.25966 0.763129 6.17431
+    endloop
+  endfacet
+  facet normal 0.70711 0.707104 0
+    outer loop
+      vertex -3.25966 0.763129 5.82569
+      vertex -3.13687 0.640341 6.17431
+      vertex -3.13687 0.640341 5.82569
+    endloop
+  endfacet
+  facet normal 0.529217 0.755792 -0.385626
+    outer loop
+      vertex -3.44548 0.541675 4.58579
+      vertex -3.5 0.616436 4.65749
+      vertex -3.37346 0.627506 4.85285
+    endloop
+  endfacet
+  facet normal 0.529218 0.755792 -0.385626
+    outer loop
+      vertex -3.5 0.616436 4.65749
+      vertex -3.44548 0.541675 4.58579
+      vertex -3.5 0.57985 4.58579
+    endloop
+  endfacet
+  facet normal 0.928303 0.248736 -0.276376
+    outer loop
+      vertex -3.09329 0.142243 4.85285
+      vertex -3.13025 0.280166 4.85285
+      vertex -3.00746 0.157378 5.15476
+    endloop
+  endfacet
+  facet normal 0.422621 0.906307 -0
+    outer loop
+      vertex -3.4019 0.862729 5.82569
+      vertex -3.5 0.908473 6.17431
+      vertex -3.4019 0.862729 6.17431
+    endloop
+  endfacet
+  facet normal 0.422621 0.906307 0
+    outer loop
+      vertex -3.5 0.908473 6.17431
+      vertex -3.4019 0.862729 5.82569
+      vertex -3.5 0.908473 5.82569
+    endloop
+  endfacet
+  facet normal 0.421 0.902831 -0.0874917
+    outer loop
+      vertex -3.4019 0.862729 5.82569
+      vertex -3.5 0.889014 5.62489
+      vertex -3.5 0.908473 5.82569
+    endloop
+  endfacet
+  facet normal 0.564375 0.806015 0.178383
+    outer loop
+      vertex -3.27911 0.739942 6.51764
+      vertex -3.44685 0.784885 6.84524
+      vertex -3.31744 0.694272 6.84524
+    endloop
+  endfacet
+  facet normal 0.564375 0.806015 0.178383
+    outer loop
+      vertex -3.41704 0.836515 6.51764
+      vertex -3.44685 0.784885 6.84524
+      vertex -3.27911 0.739942 6.51764
+    endloop
+  endfacet
+  facet normal 0.564375 -0.806015 0.178383
+    outer loop
+      vertex -3.31744 -0.694272 6.84524
+      vertex -3.44685 -0.784885 6.84524
+      vertex -3.27911 -0.739942 6.51764
+    endloop
+  endfacet
+  facet normal 0.564375 -0.806015 0.178383
+    outer loop
+      vertex -3.27911 -0.739942 6.51764
+      vertex -3.44685 -0.784885 6.84524
+      vertex -3.41704 -0.836515 6.51764
+    endloop
+  endfacet
+  facet normal 0.421 -0.902831 -0.0874916
+    outer loop
+      vertex -3.41704 -0.836515 5.48236
+      vertex -3.5 -0.889014 5.62489
+      vertex -3.5 -0.875202 5.48236
+    endloop
+  endfacet
+  facet normal 0.421 -0.902831 -0.0874918
+    outer loop
+      vertex -3.5 -0.889014 5.62489
+      vertex -3.41704 -0.836515 5.48236
+      vertex -3.4019 -0.862729 5.82569
+    endloop
+  endfacet
+  facet normal 0.551234 -0.787247 -0.276376
+    outer loop
+      vertex -3.44685 -0.784885 5.15476
+      vertex -3.49042 -0.709406 4.85285
+      vertex -3.31744 -0.694272 5.15476
+    endloop
+  endfacet
+  facet normal 0.564375 -0.806015 -0.178383
+    outer loop
+      vertex -3.41704 -0.836515 5.48236
+      vertex -3.44685 -0.784885 5.15476
+      vertex -3.27911 -0.739942 5.48236
+    endloop
+  endfacet
+  facet normal 0.421 -0.902831 -0.0874917
+    outer loop
+      vertex -3.4019 -0.862729 5.82569
+      vertex -3.5 -0.908473 5.82569
+      vertex -3.5 -0.889014 5.62489
+    endloop
+  endfacet
+  facet normal 0.571375 -0.816012 -0.0874927
+    outer loop
+      vertex -3.25966 -0.763129 5.82569
+      vertex -3.41704 -0.836515 5.48236
+      vertex -3.27911 -0.739942 5.48236
+    endloop
+  endfacet
+  facet normal 0.787247 -0.551234 0.276375
+    outer loop
+      vertex -3.11511 -0.453154 6.84524
+      vertex -3.27249 -0.526541 7.14715
+      vertex -3.20573 -0.582563 6.84524
+    endloop
+  endfacet
+  facet normal 0.679565 -0.679565 0.276375
+    outer loop
+      vertex -3.27249 -0.526541 7.14715
+      vertex -3.31744 -0.694272 6.84524
+      vertex -3.20573 -0.582563 6.84524
+    endloop
+  endfacet
+  facet normal 0.919144 -0.0804135 0.385626
+    outer loop
+      vertex -3.08085 0 7.14715
+      vertex -3.20364 -0.122787 7.41421
+      vertex -3.09329 -0.142243 7.14715
+    endloop
+  endfacet
+  facet normal 0.755797 -0.52921 0.385627
+    outer loop
+      vertex -3.28763 -0.353553 7.41421
+      vertex -3.35832 -0.454519 7.41421
+      vertex -3.19059 -0.409575 7.14715
+    endloop
+  endfacet
+  facet normal 0.806015 -0.564375 0.178385
+    outer loop
+      vertex -3.11511 -0.453154 6.84524
+      vertex -3.16006 -0.620885 6.51764
+      vertex -3.06348 -0.482963 6.51764
+    endloop
+  endfacet
+  facet normal 0.816012 -0.571375 0.0874904
+    outer loop
+      vertex -3.06348 -0.482963 6.51764
+      vertex -3.16006 -0.620885 6.51764
+      vertex -3.03727 -0.498096 6.17431
+    endloop
+  endfacet
+  facet normal 0.819151 -0.573577 0
+    outer loop
+      vertex -3.13687 -0.640341 6.17431
+      vertex -3.03727 -0.498096 5.82569
+      vertex -3.03727 -0.498096 6.17431
+    endloop
+  endfacet
+  facet normal 0.819151 -0.573577 0
+    outer loop
+      vertex -3.03727 -0.498096 5.82569
+      vertex -3.13687 -0.640341 6.17431
+      vertex -3.13687 -0.640341 5.82569
+    endloop
+  endfacet
+  facet normal 0.919144 -0.0804123 0.385626
+    outer loop
+      vertex -3.19289 0 7.41421
+      vertex -3.20364 -0.122787 7.41421
+      vertex -3.08085 0 7.14715
+    endloop
+  endfacet
+  facet normal 0.836209 -0.38993 0.385627
+    outer loop
+      vertex -3.13025 -0.280166 7.14715
+      vertex -3.23554 -0.241844 7.41421
+      vertex -3.19059 -0.409575 7.14715
+    endloop
+  endfacet
+  facet normal 0.928303 0.248736 0.276376
+    outer loop
+      vertex -3.00746 0.157378 6.84524
+      vertex -3.13025 0.280166 7.14715
+      vertex -3.09329 0.142243 7.14715
+    endloop
+  endfacet
+  facet normal 0.871006 0.406159 0.276375
+    outer loop
+      vertex -3.11511 0.453154 6.84524
+      vertex -3.19059 0.409575 7.14715
+      vertex -3.04835 0.309975 6.84524
+    endloop
+  endfacet
+  facet normal 0.919144 0.0804135 0.385626
+    outer loop
+      vertex -3.09329 0.142243 7.14715
+      vertex -3.20364 0.122787 7.41421
+      vertex -3.08085 0 7.14715
+    endloop
+  endfacet
+  facet normal 0.957392 -0.0837631 0.276376
+    outer loop
+      vertex -2.99369 0 6.84524
+      vertex -3.09329 -0.142243 7.14715
+      vertex -3.00746 -0.157378 6.84524
+    endloop
+  endfacet
+  facet normal 0.493227 -0.704392 -0.51045
+    outer loop
+      vertex -3.44548 -0.541675 4.58579
+      vertex -3.5 -0.57985 4.58579
+      vertex -3.5 -0.476701 4.44345
+    endloop
+  endfacet
+  facet normal 0.704398 -0.704393 -0.0874889
+    outer loop
+      vertex -3.13687 -0.640341 5.82569
+      vertex -3.25966 -0.763129 5.82569
+      vertex -3.16006 -0.620885 5.48236
+    endloop
+  endfacet
+  facet normal 0.704392 -0.704398 -0.0874928
+    outer loop
+      vertex -3.25966 -0.763129 5.82569
+      vertex -3.27911 -0.739942 5.48236
+      vertex -3.16006 -0.620885 5.48236
+    endloop
+  endfacet
+  facet normal 0.652412 -0.652419 -0.385627
+    outer loop
+      vertex -3.37346 -0.627506 4.85285
+      vertex -3.44548 -0.541675 4.58579
+      vertex -3.35832 -0.454519 4.58579
+    endloop
+  endfacet
+  facet normal 0.652413 -0.652419 -0.385626
+    outer loop
+      vertex -3.27249 -0.526541 4.85285
+      vertex -3.37346 -0.627506 4.85285
+      vertex -3.35832 -0.454519 4.58579
+    endloop
+  endfacet
+  facet normal 0.902831 -0.421 -0.0874906
+    outer loop
+      vertex -3.03727 -0.498096 5.82569
+      vertex -3.06348 -0.482963 5.48236
+      vertex -2.96388 -0.340718 5.82569
+    endloop
+  endfacet
+  facet normal 0.906307 -0.422621 0
+    outer loop
+      vertex -3.03727 -0.498096 6.17431
+      vertex -2.96388 -0.340718 5.82569
+      vertex -2.96388 -0.340718 6.17431
+    endloop
+  endfacet
+  facet normal 0.906307 -0.422621 0
+    outer loop
+      vertex -2.96388 -0.340718 5.82569
+      vertex -3.03727 -0.498096 6.17431
+      vertex -3.03727 -0.498096 5.82569
+    endloop
+  endfacet
+  facet normal 0.992374 -0.0868239 0.0874906
+    outer loop
+      vertex -2.9038 0 6.17431
+      vertex -2.93407 0 6.51764
+      vertex -2.91894 -0.172987 6.17431
+    endloop
+  endfacet
+  facet normal 0.902832 -0.420998 -0.0874916
+    outer loop
+      vertex -2.96388 -0.340718 5.82569
+      vertex -3.06348 -0.482963 5.48236
+      vertex -2.99233 -0.330365 5.48236
+    endloop
+  endfacet
+  facet normal 0.891771 -0.41584 0.178385
+    outer loop
+      vertex -3.04835 -0.309975 6.84524
+      vertex -3.06348 -0.482963 6.51764
+      vertex -2.99233 -0.330365 6.51764
+    endloop
+  endfacet
+  facet normal 0.962223 -0.257823 0.0874913
+    outer loop
+      vertex -2.91894 -0.172987 6.17431
+      vertex -2.99233 -0.330365 6.51764
+      vertex -2.96388 -0.340718 6.17431
+    endloop
+  endfacet
+  facet normal 0.957392 -0.0837631 -0.276376
+    outer loop
+      vertex -3.00746 -0.157378 5.15476
+      vertex -3.09329 -0.142243 4.85285
+      vertex -2.99369 0 5.15476
+    endloop
+  endfacet
+  facet normal 0.980216 0.0857599 -0.178385
+    outer loop
+      vertex -2.99369 0 5.15476
+      vertex -3.00746 0.157378 5.15476
+      vertex -2.93407 0 5.48236
+    endloop
+  endfacet
+  facet normal 0.919144 -0.0804135 -0.385626
+    outer loop
+      vertex -3.09329 -0.142243 4.85285
+      vertex -3.20364 -0.122787 4.58579
+      vertex -3.08085 0 4.85285
+    endloop
+  endfacet
+  facet normal 0.957392 0.0837597 -0.276377
+    outer loop
+      vertex -3.08085 0 4.85285
+      vertex -3.09329 0.142243 4.85285
+      vertex -2.99369 0 5.15476
+    endloop
+  endfacet
+  facet normal 0.891771 -0.41584 -0.178385
+    outer loop
+      vertex -2.99233 -0.330365 5.48236
+      vertex -3.06348 -0.482963 5.48236
+      vertex -3.04835 -0.309975 5.15476
+    endloop
+  endfacet
+  facet normal 0.928303 -0.248736 -0.276376
+    outer loop
+      vertex -3.00746 -0.157378 5.15476
+      vertex -3.13025 -0.280166 4.85285
+      vertex -3.09329 -0.142243 4.85285
+    endloop
+  endfacet
+  facet normal 0.806015 -0.564375 -0.178385
+    outer loop
+      vertex -3.06348 -0.482963 5.48236
+      vertex -3.16006 -0.620885 5.48236
+      vertex -3.11511 -0.453154 5.15476
+    endloop
+  endfacet
+  facet normal 0.806014 -0.564375 -0.178385
+    outer loop
+      vertex -3.16006 -0.620885 5.48236
+      vertex -3.20573 -0.582563 5.15476
+      vertex -3.11511 -0.453154 5.15476
+    endloop
+  endfacet
+  facet normal 0.704398 0.49322 -0.510449
+    outer loop
+      vertex -3.28763 0.353553 4.58579
+      vertex -3.40327 0.286788 4.3617
+      vertex -3.35832 0.454519 4.58579
+    endloop
+  endfacet
+  facet normal 0.928303 -0.248736 -0.276376
+    outer loop
+      vertex -3.04835 -0.309975 5.15476
+      vertex -3.13025 -0.280166 4.85285
+      vertex -3.00746 -0.157378 5.15476
+    endloop
+  endfacet
+  facet normal 0.980216 -0.0857599 -0.178385
+    outer loop
+      vertex -2.93407 0 5.48236
+      vertex -3.00746 -0.157378 5.15476
+      vertex -2.99369 0 5.15476
+    endloop
+  endfacet
+  facet normal 0.980216 -0.0857615 -0.178384
+    outer loop
+      vertex -2.94875 -0.16773 5.48236
+      vertex -3.00746 -0.157378 5.15476
+      vertex -2.93407 0 5.48236
+    endloop
+  endfacet
+  facet normal 0.755797 -0.52921 -0.385627
+    outer loop
+      vertex -3.19059 -0.409575 4.85285
+      vertex -3.35832 -0.454519 4.58579
+      vertex -3.28763 -0.353553 4.58579
+    endloop
+  endfacet
+  facet normal 0.679561 -0.679568 -0.276377
+    outer loop
+      vertex -3.31744 -0.694272 5.15476
+      vertex -3.37346 -0.627506 4.85285
+      vertex -3.27249 -0.526541 4.85285
+    endloop
+  endfacet
+  facet normal 0.836209 -0.389931 -0.385627
+    outer loop
+      vertex -3.19059 -0.409575 4.85285
+      vertex -3.28763 -0.353553 4.58579
+      vertex -3.23554 -0.241844 4.58579
+    endloop
+  endfacet
+  facet normal 0.704392 0.704398 -0.0874928
+    outer loop
+      vertex -3.16006 0.620885 5.48236
+      vertex -3.27911 0.739942 5.48236
+      vertex -3.25966 0.763129 5.82569
+    endloop
+  endfacet
+  facet normal 0.415843 0.89177 -0.178383
+    outer loop
+      vertex -3.41704 0.836515 5.48236
+      vertex -3.5 0.838039 5.29658
+      vertex -3.5 0.875202 5.48236
+    endloop
+  endfacet
+  facet normal 0.415842 0.891771 -0.178383
+    outer loop
+      vertex -3.5 0.838039 5.29658
+      vertex -3.41704 0.836515 5.48236
+      vertex -3.44685 0.784885 5.15476
+    endloop
+  endfacet
+  facet normal 0.551237 0.787244 -0.276377
+    outer loop
+      vertex -3.37346 0.627506 4.85285
+      vertex -3.49042 0.709406 4.85285
+      vertex -3.31744 0.694272 5.15476
+    endloop
+  endfacet
+  facet normal 0.529215 0.755795 -0.385624
+    outer loop
+      vertex -3.37346 0.627506 4.85285
+      vertex -3.5 0.692819 4.80719
+      vertex -3.49042 0.709406 4.85285
+    endloop
+  endfacet
+  facet normal 0.529215 0.755794 -0.385625
+    outer loop
+      vertex -3.5 0.692819 4.80719
+      vertex -3.37346 0.627506 4.85285
+      vertex -3.5 0.616436 4.65749
+    endloop
+  endfacet
+  facet normal 0.569893 0.152704 -0.807406
+    outer loop
+      vertex -3.4838 0.0733862 4.18738
+      vertex -3.5 0.0748034 4.17622
+      vertex -3.5 0.133838 4.18738
+    endloop
+  endfacet
+  facet normal 0.587745 -0.0514173 0.807411
+    outer loop
+      vertex -3.5 -0.0658329 7.82489
+      vertex -3.47738 0 7.81262
+      vertex -3.5 0 7.82908
+    endloop
+  endfacet
+  facet normal 0.587748 -0.0514187 0.807409
+    outer loop
+      vertex -3.47738 0 7.81262
+      vertex -3.5 -0.0658329 7.82489
+      vertex -3.4838 -0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.704397 -0.493221 0.510449
+    outer loop
+      vertex -3.40327 -0.286788 7.6383
+      vertex -3.46061 -0.368688 7.6383
+      vertex -3.35832 -0.454519 7.41421
+    endloop
+  endfacet
+  facet normal 0.608043 -0.608051 0.510449
+    outer loop
+      vertex -3.5 -0.476701 7.55655
+      vertex -3.46061 -0.368688 7.6383
+      vertex -3.5 -0.408073 7.6383
+    endloop
+  endfacet
+  facet normal 0.608042 -0.608051 0.51045
+    outer loop
+      vertex -3.46061 -0.368688 7.6383
+      vertex -3.5 -0.476701 7.55655
+      vertex -3.44548 -0.541675 7.41421
+    endloop
+  endfacet
+  facet normal 0.493227 -0.704392 0.51045
+    outer loop
+      vertex -3.5 -0.476701 7.55655
+      vertex -3.5 -0.57985 7.41421
+      vertex -3.44548 -0.541675 7.41421
+    endloop
+  endfacet
+  facet normal 0.704398 0.49322 0.510449
+    outer loop
+      vertex -3.35832 0.454519 7.41421
+      vertex -3.40327 0.286788 7.6383
+      vertex -3.28763 0.353553 7.41421
+    endloop
+  endfacet
+  facet normal 0.731358 0.195984 0.653228
+    outer loop
+      vertex -3.5 0.133838 7.81262
+      vertex -3.36101 0.196175 7.6383
+      vertex -3.5 0.145588 7.80909
+    endloop
+  endfacet
+  facet normal 0.731362 0.19597 0.653227
+    outer loop
+      vertex -3.36101 0.196175 7.6383
+      vertex -3.5 0.133838 7.81262
+      vertex -3.4838 0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.679565 0.679565 0.276375
+    outer loop
+      vertex -3.20573 0.582563 6.84524
+      vertex -3.31744 0.694272 6.84524
+      vertex -3.27249 0.526541 7.14715
+    endloop
+  endfacet
+  facet normal 0.787247 0.551234 0.276375
+    outer loop
+      vertex -3.20573 0.582563 6.84524
+      vertex -3.27249 0.526541 7.14715
+      vertex -3.11511 0.453154 6.84524
+    endloop
+  endfacet
+  facet normal 0.620231 0.43429 0.653227
+    outer loop
+      vertex -3.5 0.278325 7.73578
+      vertex -3.5 0.230939 7.76728
+      vertex -3.40327 0.286788 7.6383
+    endloop
+  endfacet
+  facet normal 0.652413 0.652419 0.385626
+    outer loop
+      vertex -3.27249 0.526541 7.14715
+      vertex -3.37346 0.627506 7.14715
+      vertex -3.35832 0.454519 7.41421
+    endloop
+  endfacet
+  facet normal 0.535386 -0.535405 0.653225
+    outer loop
+      vertex -3.5 -0.335639 7.69767
+      vertex -3.5 -0.358134 7.67923
+      vertex -3.46061 -0.368688 7.6383
+    endloop
+  endfacet
+  facet normal 0.652412 0.652419 0.385627
+    outer loop
+      vertex -3.37346 0.627506 7.14715
+      vertex -3.44548 0.541675 7.41421
+      vertex -3.35832 0.454519 7.41421
+    endloop
+  endfacet
+  facet normal 0.529218 0.755792 0.385626
+    outer loop
+      vertex -3.44548 0.541675 7.41421
+      vertex -3.5 0.616436 7.34251
+      vertex -3.5 0.57985 7.41421
+    endloop
+  endfacet
+  facet normal 0.529217 0.755792 0.385626
+    outer loop
+      vertex -3.5 0.616436 7.34251
+      vertex -3.44548 0.541675 7.41421
+      vertex -3.37346 0.627506 7.14715
+    endloop
+  endfacet
+  facet normal 0.406154 0.871008 0.276376
+    outer loop
+      vertex -3.49042 0.709406 7.14715
+      vertex -3.5 0.780235 6.93801
+      vertex -3.5 0.713872 7.14715
+    endloop
+  endfacet
+  facet normal 0.406156 0.871007 0.276376
+    outer loop
+      vertex -3.5 0.780235 6.93801
+      vertex -3.49042 0.709406 7.14715
+      vertex -3.44685 0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.389929 0.836212 0.385624
+    outer loop
+      vertex -3.5 0.713872 7.14715
+      vertex -3.5 0.692819 7.1928
+      vertex -3.49042 0.709406 7.14715
+    endloop
+  endfacet
+  facet normal 0.816012 0.571375 0.0874904
+    outer loop
+      vertex -3.03727 0.498096 6.17431
+      vertex -3.16006 0.620885 6.51764
+      vertex -3.06348 0.482963 6.51764
+    endloop
+  endfacet
+  facet normal 0.571375 0.816012 -0.0874927
+    outer loop
+      vertex -3.27911 0.739942 5.48236
+      vertex -3.41704 0.836515 5.48236
+      vertex -3.25966 0.763129 5.82569
+    endloop
+  endfacet
+  facet normal 0.704398 0.704393 -0.0874889
+    outer loop
+      vertex -3.16006 0.620885 5.48236
+      vertex -3.25966 0.763129 5.82569
+      vertex -3.13687 0.640341 5.82569
+    endloop
+  endfacet
+  facet normal 0.980216 0.0857599 0.178385
+    outer loop
+      vertex -2.93407 0 6.51764
+      vertex -3.00746 0.157378 6.84524
+      vertex -2.99369 0 6.84524
+    endloop
+  endfacet
+  facet normal 0.980216 -0.0857599 0.178385
+    outer loop
+      vertex -2.99369 0 6.84524
+      vertex -3.00746 -0.157378 6.84524
+      vertex -2.93407 0 6.51764
+    endloop
+  endfacet
+  facet normal 0.406156 0.871007 0.276376
+    outer loop
+      vertex -3.5 0.809671 6.84524
+      vertex -3.5 0.780235 6.93801
+      vertex -3.44685 0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.415842 0.891771 0.178383
+    outer loop
+      vertex -3.41704 0.836515 6.51764
+      vertex -3.5 0.838039 6.70342
+      vertex -3.44685 0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.415843 0.89177 0.178383
+    outer loop
+      vertex -3.5 0.838039 6.70342
+      vertex -3.41704 0.836515 6.51764
+      vertex -3.5 0.875202 6.51764
+    endloop
+  endfacet
+  facet normal 0.421 -0.902831 0.0874916
+    outer loop
+      vertex -3.5 -0.889014 6.37511
+      vertex -3.41704 -0.836515 6.51764
+      vertex -3.5 -0.875202 6.51764
+    endloop
+  endfacet
+  facet normal 0.421 -0.902831 0.0874918
+    outer loop
+      vertex -3.41704 -0.836515 6.51764
+      vertex -3.5 -0.889014 6.37511
+      vertex -3.4019 -0.862729 6.17431
+    endloop
+  endfacet
+  facet normal 0.571375 -0.816012 0.0874927
+    outer loop
+      vertex -3.27911 -0.739942 6.51764
+      vertex -3.41704 -0.836515 6.51764
+      vertex -3.25966 -0.763129 6.17431
+    endloop
+  endfacet
+  facet normal 0.704392 -0.704398 0.0874928
+    outer loop
+      vertex -3.16006 -0.620885 6.51764
+      vertex -3.27911 -0.739942 6.51764
+      vertex -3.25966 -0.763129 6.17431
+    endloop
+  endfacet
+  facet normal 0.695763 -0.695768 0.178383
+    outer loop
+      vertex -3.16006 -0.620885 6.51764
+      vertex -3.31744 -0.694272 6.84524
+      vertex -3.27911 -0.739942 6.51764
+    endloop
+  endfacet
+  facet normal 0.571374 -0.816013 -0.0874919
+    outer loop
+      vertex -3.4019 -0.862729 5.82569
+      vertex -3.41704 -0.836515 5.48236
+      vertex -3.25966 -0.763129 5.82569
+    endloop
+  endfacet
+  facet normal 0.573574 -0.819154 0
+    outer loop
+      vertex -3.4019 -0.862729 5.82569
+      vertex -3.25966 -0.763129 6.17431
+      vertex -3.4019 -0.862729 6.17431
+    endloop
+  endfacet
+  facet normal 0.573574 -0.819154 0
+    outer loop
+      vertex -3.25966 -0.763129 6.17431
+      vertex -3.4019 -0.862729 5.82569
+      vertex -3.25966 -0.763129 5.82569
+    endloop
+  endfacet
+  facet normal 0.415843 -0.89177 0.178383
+    outer loop
+      vertex -3.41704 -0.836515 6.51764
+      vertex -3.5 -0.838039 6.70342
+      vertex -3.5 -0.875202 6.51764
+    endloop
+  endfacet
+  facet normal 0.415842 -0.891771 0.178383
+    outer loop
+      vertex -3.5 -0.838039 6.70342
+      vertex -3.41704 -0.836515 6.51764
+      vertex -3.44685 -0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.415839 -0.891772 0.178385
+    outer loop
+      vertex -3.5 -0.809671 6.84524
+      vertex -3.5 -0.838039 6.70342
+      vertex -3.44685 -0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.779341 -0.363413 0.510449
+    outer loop
+      vertex -3.23554 -0.241844 7.41421
+      vertex -3.40327 -0.286788 7.6383
+      vertex -3.28763 -0.353553 7.41421
+    endloop
+  endfacet
+  facet normal 0.704398 -0.49322 0.510449
+    outer loop
+      vertex -3.28763 -0.353553 7.41421
+      vertex -3.40327 -0.286788 7.6383
+      vertex -3.35832 -0.454519 7.41421
+    endloop
+  endfacet
+  facet normal 0.891216 -0.238802 0.385627
+    outer loop
+      vertex -3.20364 -0.122787 7.41421
+      vertex -3.23554 -0.241844 7.41421
+      vertex -3.13025 -0.280166 7.14715
+    endloop
+  endfacet
+  facet normal 0.919144 0.0804123 0.385626
+    outer loop
+      vertex -3.08085 0 7.14715
+      vertex -3.20364 0.122787 7.41421
+      vertex -3.19289 0 7.41421
+    endloop
+  endfacet
+  facet normal 0.871007 -0.406157 0.276376
+    outer loop
+      vertex -3.13025 -0.280166 7.14715
+      vertex -3.19059 -0.409575 7.14715
+      vertex -3.04835 -0.309975 6.84524
+    endloop
+  endfacet
+  facet normal 0.928303 -0.248736 0.276376
+    outer loop
+      vertex -3.00746 -0.157378 6.84524
+      vertex -3.13025 -0.280166 7.14715
+      vertex -3.04835 -0.309975 6.84524
+    endloop
+  endfacet
+  facet normal 0.836209 0.38993 0.385627
+    outer loop
+      vertex -3.19059 0.409575 7.14715
+      vertex -3.23554 0.241844 7.41421
+      vertex -3.13025 0.280166 7.14715
+    endloop
+  endfacet
+  facet normal 0.871007 0.406157 0.276376
+    outer loop
+      vertex -3.04835 0.309975 6.84524
+      vertex -3.19059 0.409575 7.14715
+      vertex -3.13025 0.280166 7.14715
+    endloop
+  endfacet
+  facet normal 0.891771 0.41584 0.178385
+    outer loop
+      vertex -2.99233 0.330365 6.51764
+      vertex -3.06348 0.482963 6.51764
+      vertex -3.04835 0.309975 6.84524
+    endloop
+  endfacet
+  facet normal 0.89177 0.415842 0.178385
+    outer loop
+      vertex -3.06348 0.482963 6.51764
+      vertex -3.11511 0.453154 6.84524
+      vertex -3.04835 0.309975 6.84524
+    endloop
+  endfacet
+  facet normal 0.957392 -0.0837597 0.276377
+    outer loop
+      vertex -3.08085 0 7.14715
+      vertex -3.09329 -0.142243 7.14715
+      vertex -2.99369 0 6.84524
+    endloop
+  endfacet
+  facet normal 0.957392 0.0837597 0.276377
+    outer loop
+      vertex -2.99369 0 6.84524
+      vertex -3.09329 0.142243 7.14715
+      vertex -3.08085 0 7.14715
+    endloop
+  endfacet
+  facet normal 0.551237 -0.787244 -0.276377
+    outer loop
+      vertex -3.31744 -0.694272 5.15476
+      vertex -3.49042 -0.709406 4.85285
+      vertex -3.37346 -0.627506 4.85285
+    endloop
+  endfacet
+  facet normal 0.529218 -0.755792 -0.385626
+    outer loop
+      vertex -3.44548 -0.541675 4.58579
+      vertex -3.5 -0.616436 4.65749
+      vertex -3.5 -0.57985 4.58579
+    endloop
+  endfacet
+  facet normal 0.529217 -0.755792 -0.385626
+    outer loop
+      vertex -3.5 -0.616436 4.65749
+      vertex -3.44548 -0.541675 4.58579
+      vertex -3.37346 -0.627506 4.85285
+    endloop
+  endfacet
+  facet normal 0.962223 -0.257823 0.0874916
+    outer loop
+      vertex -2.94875 -0.16773 6.51764
+      vertex -2.99233 -0.330365 6.51764
+      vertex -2.91894 -0.172987 6.17431
+    endloop
+  endfacet
+  facet normal 0.965927 -0.258816 0
+    outer loop
+      vertex -2.96388 -0.340718 6.17431
+      vertex -2.91894 -0.172987 5.82569
+      vertex -2.91894 -0.172987 6.17431
+    endloop
+  endfacet
+  facet normal 0.965927 -0.258816 0
+    outer loop
+      vertex -2.91894 -0.172987 5.82569
+      vertex -2.96388 -0.340718 6.17431
+      vertex -2.96388 -0.340718 5.82569
+    endloop
+  endfacet
+  facet normal 0.992374 0.0868253 -0.0874913
+    outer loop
+      vertex -2.93407 0 5.48236
+      vertex -2.94875 0.16773 5.48236
+      vertex -2.91894 0.172987 5.82569
+    endloop
+  endfacet
+  facet normal 0.980216 0.0857615 -0.178384
+    outer loop
+      vertex -2.93407 0 5.48236
+      vertex -3.00746 0.157378 5.15476
+      vertex -2.94875 0.16773 5.48236
+    endloop
+  endfacet
+  facet normal 0.830607 0.222559 -0.510451
+    outer loop
+      vertex -3.33514 0.0995998 4.3617
+      vertex -3.36101 0.196175 4.3617
+      vertex -3.20364 0.122787 4.58579
+    endloop
+  endfacet
+  facet normal 0.787247 0.551234 -0.276375
+    outer loop
+      vertex -3.19059 0.409575 4.85285
+      vertex -3.27249 0.526541 4.85285
+      vertex -3.11511 0.453154 5.15476
+    endloop
+  endfacet
+  facet normal 0.830607 -0.222562 -0.51045
+    outer loop
+      vertex -3.23554 -0.241844 4.58579
+      vertex -3.36101 -0.196175 4.3617
+      vertex -3.20364 -0.122787 4.58579
+    endloop
+  endfacet
+  facet normal 0.891216 -0.238802 -0.385627
+    outer loop
+      vertex -3.13025 -0.280166 4.85285
+      vertex -3.23554 -0.241844 4.58579
+      vertex -3.20364 -0.122787 4.58579
+    endloop
+  endfacet
+  facet normal 0.620231 -0.43429 -0.653227
+    outer loop
+      vertex -3.40327 -0.286788 4.3617
+      vertex -3.5 -0.278325 4.26422
+      vertex -3.5 -0.230939 4.23272
+    endloop
+  endfacet
+  facet normal 0.608043 -0.60805 -0.510449
+    outer loop
+      vertex -3.44548 -0.541675 4.58579
+      vertex -3.46061 -0.368688 4.3617
+      vertex -3.35832 -0.454519 4.58579
+    endloop
+  endfacet
+  facet normal 0.608043 -0.608051 -0.510449
+    outer loop
+      vertex -3.46061 -0.368688 4.3617
+      vertex -3.5 -0.476701 4.44345
+      vertex -3.5 -0.408073 4.3617
+    endloop
+  endfacet
+  facet normal 0.608042 -0.608051 -0.51045
+    outer loop
+      vertex -3.5 -0.476701 4.44345
+      vertex -3.46061 -0.368688 4.3617
+      vertex -3.44548 -0.541675 4.58579
+    endloop
+  endfacet
+  facet normal 0.652412 0.652419 -0.385627
+    outer loop
+      vertex -3.35832 0.454519 4.58579
+      vertex -3.44548 0.541675 4.58579
+      vertex -3.37346 0.627506 4.85285
+    endloop
+  endfacet
+  facet normal 0.856634 0.0749528 -0.510451
+    outer loop
+      vertex -3.32642 0 4.3617
+      vertex -3.33514 0.0995998 4.3617
+      vertex -3.20364 0.122787 4.58579
+    endloop
+  endfacet
+  facet normal 0.406156 0.871007 -0.276376
+    outer loop
+      vertex -3.49042 0.709406 4.85285
+      vertex -3.5 0.780235 5.06199
+      vertex -3.44685 0.784885 5.15476
+    endloop
+  endfacet
+  facet normal 0.406154 0.871008 -0.276376
+    outer loop
+      vertex -3.5 0.780235 5.06199
+      vertex -3.49042 0.709406 4.85285
+      vertex -3.5 0.713872 4.85285
+    endloop
+  endfacet
+  facet normal 0.389929 0.836212 -0.385624
+    outer loop
+      vertex -3.49042 0.709406 4.85285
+      vertex -3.5 0.692819 4.80719
+      vertex -3.5 0.713872 4.85285
+    endloop
+  endfacet
+  facet normal 0.493227 0.704392 -0.51045
+    outer loop
+      vertex -3.44548 0.541675 4.58579
+      vertex -3.5 0.476701 4.44345
+      vertex -3.5 0.57985 4.58579
+    endloop
+  endfacet
+  facet normal 0.686223 0.319989 -0.653227
+    outer loop
+      vertex -3.36101 0.196175 4.3617
+      vertex -3.5 0.230939 4.23272
+      vertex -3.40327 0.286788 4.3617
+    endloop
+  endfacet
+  facet normal 0.686223 0.319992 -0.653226
+    outer loop
+      vertex -3.5 0.230939 4.23272
+      vertex -3.36101 0.196175 4.3617
+      vertex -3.5 0.208334 4.22165
+    endloop
+  endfacet
+  facet normal 0.587756 -0.0513921 0.807404
+    outer loop
+      vertex -3.5 -0.0658329 7.82489
+      vertex -3.5 -0.07053 7.82459
+      vertex -3.4838 -0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.686223 -0.319992 0.653226
+    outer loop
+      vertex -3.5 -0.230939 7.76728
+      vertex -3.36101 -0.196175 7.6383
+      vertex -3.5 -0.208334 7.77835
+    endloop
+  endfacet
+  facet normal 0.686223 -0.319989 0.653227
+    outer loop
+      vertex -3.36101 -0.196175 7.6383
+      vertex -3.5 -0.230939 7.76728
+      vertex -3.40327 -0.286788 7.6383
+    endloop
+  endfacet
+  facet normal 0.731358 -0.195984 0.653228
+    outer loop
+      vertex -3.36101 -0.196175 7.6383
+      vertex -3.5 -0.133838 7.81262
+      vertex -3.5 -0.145588 7.80909
+    endloop
+  endfacet
+  facet normal 0.731362 -0.19597 0.653227
+    outer loop
+      vertex -3.5 -0.133838 7.81262
+      vertex -3.36101 -0.196175 7.6383
+      vertex -3.4838 -0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.652413 -0.652419 0.385626
+    outer loop
+      vertex -3.35832 -0.454519 7.41421
+      vertex -3.37346 -0.627506 7.14715
+      vertex -3.27249 -0.526541 7.14715
+    endloop
+  endfacet
+  facet normal 0.529215 -0.755795 0.385624
+    outer loop
+      vertex -3.37346 -0.627506 7.14715
+      vertex -3.5 -0.692819 7.1928
+      vertex -3.49042 -0.709406 7.14715
+    endloop
+  endfacet
+  facet normal 0.529215 -0.755794 0.385625
+    outer loop
+      vertex -3.5 -0.692819 7.1928
+      vertex -3.37346 -0.627506 7.14715
+      vertex -3.5 -0.616436 7.34251
+    endloop
+  endfacet
+  facet normal 0.830607 0.222559 0.510451
+    outer loop
+      vertex -3.20364 0.122787 7.41421
+      vertex -3.36101 0.196175 7.6383
+      vertex -3.33514 0.0995998 7.6383
+    endloop
+  endfacet
+  facet normal 0.731364 0.195967 0.653226
+    outer loop
+      vertex -3.36101 0.196175 7.6383
+      vertex -3.4838 0.0733862 7.81262
+      vertex -3.33514 0.0995998 7.6383
+    endloop
+  endfacet
+  facet normal 0.836209 0.389931 0.385627
+    outer loop
+      vertex -3.19059 0.409575 7.14715
+      vertex -3.28763 0.353553 7.41421
+      vertex -3.23554 0.241844 7.41421
+    endloop
+  endfacet
+  facet normal 0.704397 0.493221 0.510449
+    outer loop
+      vertex -3.35832 0.454519 7.41421
+      vertex -3.46061 0.368688 7.6383
+      vertex -3.40327 0.286788 7.6383
+    endloop
+  endfacet
+  facet normal 0.686223 0.319992 0.653226
+    outer loop
+      vertex -3.36101 0.196175 7.6383
+      vertex -3.5 0.230939 7.76728
+      vertex -3.5 0.208334 7.77835
+    endloop
+  endfacet
+  facet normal 0.686223 0.319989 0.653227
+    outer loop
+      vertex -3.5 0.230939 7.76728
+      vertex -3.36101 0.196175 7.6383
+      vertex -3.40327 0.286788 7.6383
+    endloop
+  endfacet
+  facet normal 0.779342 0.363411 0.510449
+    outer loop
+      vertex -3.23554 0.241844 7.41421
+      vertex -3.40327 0.286788 7.6383
+      vertex -3.36101 0.196175 7.6383
+    endloop
+  endfacet
+  facet normal 0.569893 0.152704 0.807406
+    outer loop
+      vertex -3.5 0.133838 7.81262
+      vertex -3.5 0.0748034 7.82378
+      vertex -3.4838 0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.493227 0.704392 0.51045
+    outer loop
+      vertex -3.5 0.57985 7.41421
+      vertex -3.5 0.476701 7.55655
+      vertex -3.44548 0.541675 7.41421
+    endloop
+  endfacet
+  facet normal 0.608043 0.608051 0.510449
+    outer loop
+      vertex -3.46061 0.368688 7.6383
+      vertex -3.5 0.476701 7.55655
+      vertex -3.5 0.408073 7.6383
+    endloop
+  endfacet
+  facet normal 0.608042 0.608051 0.51045
+    outer loop
+      vertex -3.5 0.476701 7.55655
+      vertex -3.46061 0.368688 7.6383
+      vertex -3.44548 0.541675 7.41421
+    endloop
+  endfacet
+  facet normal 0.965927 0.258816 0
+    outer loop
+      vertex -2.91894 0.172987 6.17431
+      vertex -2.96388 0.340718 5.82569
+      vertex -2.96388 0.340718 6.17431
+    endloop
+  endfacet
+  facet normal 0.965927 0.258816 0
+    outer loop
+      vertex -2.96388 0.340718 5.82569
+      vertex -2.91894 0.172987 6.17431
+      vertex -2.91894 0.172987 5.82569
+    endloop
+  endfacet
+  facet normal 0.962223 0.257823 -0.0874913
+    outer loop
+      vertex -2.91894 0.172987 5.82569
+      vertex -2.99233 0.330365 5.48236
+      vertex -2.96388 0.340718 5.82569
+    endloop
+  endfacet
+  facet normal 0.902832 0.420998 -0.0874916
+    outer loop
+      vertex -2.99233 0.330365 5.48236
+      vertex -3.06348 0.482963 5.48236
+      vertex -2.96388 0.340718 5.82569
+    endloop
+  endfacet
+  facet normal 0.891771 0.41584 -0.178385
+    outer loop
+      vertex -3.04835 0.309975 5.15476
+      vertex -3.06348 0.482963 5.48236
+      vertex -2.99233 0.330365 5.48236
+    endloop
+  endfacet
+  facet normal 0.695763 0.695768 -0.178383
+    outer loop
+      vertex -3.16006 0.620885 5.48236
+      vertex -3.31744 0.694272 5.15476
+      vertex -3.27911 0.739942 5.48236
+    endloop
+  endfacet
+  facet normal 0.564375 0.806015 -0.178383
+    outer loop
+      vertex -3.31744 0.694272 5.15476
+      vertex -3.44685 0.784885 5.15476
+      vertex -3.27911 0.739942 5.48236
+    endloop
+  endfacet
+  facet normal 0.406156 -0.871007 -0.276376
+    outer loop
+      vertex -3.44685 -0.784885 5.15476
+      vertex -3.5 -0.809671 5.15476
+      vertex -3.5 -0.780235 5.06199
+    endloop
+  endfacet
+  facet normal 0.415839 -0.891772 -0.178385
+    outer loop
+      vertex -3.44685 -0.784885 5.15476
+      vertex -3.5 -0.838039 5.29658
+      vertex -3.5 -0.809671 5.15476
+    endloop
+  endfacet
+  facet normal 0.856637 -0.0749438 0.510447
+    outer loop
+      vertex -3.19289 0 7.41421
+      vertex -3.32642 0 7.6383
+      vertex -3.20364 -0.122787 7.41421
+    endloop
+  endfacet
+  facet normal 0.856634 -0.0749528 0.510451
+    outer loop
+      vertex -3.32642 0 7.6383
+      vertex -3.33514 -0.0995998 7.6383
+      vertex -3.20364 -0.122787 7.41421
+    endloop
+  endfacet
+  facet normal 0.529215 -0.755795 -0.385624
+    outer loop
+      vertex -3.5 -0.692819 4.80719
+      vertex -3.37346 -0.627506 4.85285
+      vertex -3.49042 -0.709406 4.85285
+    endloop
+  endfacet
+  facet normal 0.529215 -0.755794 -0.385625
+    outer loop
+      vertex -3.37346 -0.627506 4.85285
+      vertex -3.5 -0.692819 4.80719
+      vertex -3.5 -0.616436 4.65749
+    endloop
+  endfacet
+  facet normal 0.389929 -0.836212 -0.385624
+    outer loop
+      vertex -3.49042 -0.709406 4.85285
+      vertex -3.5 -0.713872 4.85285
+      vertex -3.5 -0.692819 4.80719
+    endloop
+  endfacet
+  facet normal 0.535386 -0.535405 -0.653225
+    outer loop
+      vertex -3.46061 -0.368688 4.3617
+      vertex -3.5 -0.358134 4.32076
+      vertex -3.5 -0.335639 4.30233
+    endloop
+  endfacet
+  facet normal 0.535391 -0.535398 -0.653228
+    outer loop
+      vertex -3.46061 -0.368688 4.3617
+      vertex -3.5 -0.408073 4.3617
+      vertex -3.5 -0.358134 4.32076
+    endloop
+  endfacet
+  facet normal 0.902832 -0.420998 0.0874916
+    outer loop
+      vertex -2.99233 -0.330365 6.51764
+      vertex -3.06348 -0.482963 6.51764
+      vertex -2.96388 -0.340718 6.17431
+    endloop
+  endfacet
+  facet normal 0.902831 -0.421 0.0874906
+    outer loop
+      vertex -2.96388 -0.340718 6.17431
+      vertex -3.06348 -0.482963 6.51764
+      vertex -3.03727 -0.498096 6.17431
+    endloop
+  endfacet
+  facet normal 0.754281 -0.0659973 -0.653226
+    outer loop
+      vertex -3.33514 -0.0995998 4.3617
+      vertex -3.4838 -0.0733862 4.18738
+      vertex -3.32642 0 4.3617
+    endloop
+  endfacet
+  facet normal 0.856634 -0.0749528 -0.510451
+    outer loop
+      vertex -3.20364 -0.122787 4.58579
+      vertex -3.33514 -0.0995998 4.3617
+      vertex -3.32642 0 4.3617
+    endloop
+  endfacet
+  facet normal 0.704397 -0.493221 -0.510449
+    outer loop
+      vertex -3.35832 -0.454519 4.58579
+      vertex -3.46061 -0.368688 4.3617
+      vertex -3.40327 -0.286788 4.3617
+    endloop
+  endfacet
+  facet normal 0.779342 -0.363411 -0.510449
+    outer loop
+      vertex -3.23554 -0.241844 4.58579
+      vertex -3.40327 -0.286788 4.3617
+      vertex -3.36101 -0.196175 4.3617
+    endloop
+  endfacet
+  facet normal 0.620233 -0.434289 -0.653226
+    outer loop
+      vertex -3.5 -0.335639 4.30233
+      vertex -3.40327 -0.286788 4.3617
+      vertex -3.46061 -0.368688 4.3617
+    endloop
+  endfacet
+  facet normal 0.620233 -0.434285 -0.653228
+    outer loop
+      vertex -3.40327 -0.286788 4.3617
+      vertex -3.5 -0.335639 4.30233
+      vertex -3.5 -0.278325 4.26422
+    endloop
+  endfacet
+  facet normal 0.686223 -0.319992 -0.653226
+    outer loop
+      vertex -3.36101 -0.196175 4.3617
+      vertex -3.5 -0.230939 4.23272
+      vertex -3.5 -0.208334 4.22165
+    endloop
+  endfacet
+  facet normal 0.686223 -0.319989 -0.653227
+    outer loop
+      vertex -3.5 -0.230939 4.23272
+      vertex -3.36101 -0.196175 4.3617
+      vertex -3.40327 -0.286788 4.3617
+    endloop
+  endfacet
+  facet normal 0.587745 0.0514173 -0.807411
+    outer loop
+      vertex -3.5 0.0658329 4.17511
+      vertex -3.47738 0 4.18738
+      vertex -3.5 0 4.17092
+    endloop
+  endfacet
+  facet normal 0.587748 0.0514187 -0.807409
+    outer loop
+      vertex -3.47738 0 4.18738
+      vertex -3.5 0.0658329 4.17511
+      vertex -3.4838 0.0733862 4.18738
+    endloop
+  endfacet
+  facet normal 0.652413 0.652419 -0.385626
+    outer loop
+      vertex -3.35832 0.454519 4.58579
+      vertex -3.37346 0.627506 4.85285
+      vertex -3.27249 0.526541 4.85285
+    endloop
+  endfacet
+  facet normal 0.620233 0.434285 -0.653228
+    outer loop
+      vertex -3.5 0.335639 4.30233
+      vertex -3.40327 0.286788 4.3617
+      vertex -3.5 0.278325 4.26422
+    endloop
+  endfacet
+  facet normal 0.620233 0.434289 -0.653226
+    outer loop
+      vertex -3.40327 0.286788 4.3617
+      vertex -3.5 0.335639 4.30233
+      vertex -3.46061 0.368688 4.3617
+    endloop
+  endfacet
+  facet normal 0.415839 0.891772 -0.178385
+    outer loop
+      vertex -3.44685 0.784885 5.15476
+      vertex -3.5 0.809671 5.15476
+      vertex -3.5 0.838039 5.29658
+    endloop
+  endfacet
+  facet normal 0.406156 0.871007 -0.276376
+    outer loop
+      vertex -3.44685 0.784885 5.15476
+      vertex -3.5 0.780235 5.06199
+      vertex -3.5 0.809671 5.15476
+    endloop
+  endfacet
+  facet normal 0.587748 0.0514187 0.807409
+    outer loop
+      vertex -3.5 0.0658329 7.82489
+      vertex -3.47738 0 7.81262
+      vertex -3.4838 0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.587745 0.0514173 0.807411
+    outer loop
+      vertex -3.47738 0 7.81262
+      vertex -3.5 0.0658329 7.82489
+      vertex -3.5 0 7.82908
+    endloop
+  endfacet
+  facet normal 0.587756 0.0513921 0.807404
+    outer loop
+      vertex -3.5 0.07053 7.82459
+      vertex -3.5 0.0658329 7.82489
+      vertex -3.4838 0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.569893 -0.152704 0.807406
+    outer loop
+      vertex -3.5 -0.0748034 7.82378
+      vertex -3.5 -0.133838 7.81262
+      vertex -3.4838 -0.0733862 7.81262
+    endloop
+  endfacet
+  facet normal 0.620233 -0.434285 0.653228
+    outer loop
+      vertex -3.5 -0.335639 7.69767
+      vertex -3.40327 -0.286788 7.6383
+      vertex -3.5 -0.278325 7.73578
+    endloop
+  endfacet
+  facet normal 0.620233 -0.434289 0.653226
+    outer loop
+      vertex -3.40327 -0.286788 7.6383
+      vertex -3.5 -0.335639 7.69767
+      vertex -3.46061 -0.368688 7.6383
+    endloop
+  endfacet
+  facet normal 0.620231 -0.43429 0.653227
+    outer loop
+      vertex -3.5 -0.230939 7.76728
+      vertex -3.5 -0.278325 7.73578
+      vertex -3.40327 -0.286788 7.6383
+    endloop
+  endfacet
+  facet normal 0.608043 -0.60805 0.510449
+    outer loop
+      vertex -3.35832 -0.454519 7.41421
+      vertex -3.46061 -0.368688 7.6383
+      vertex -3.44548 -0.541675 7.41421
+    endloop
+  endfacet
+  facet normal 0.535391 -0.535398 0.653228
+    outer loop
+      vertex -3.5 -0.358134 7.67923
+      vertex -3.5 -0.408073 7.6383
+      vertex -3.46061 -0.368688 7.6383
+    endloop
+  endfacet
+  facet normal 0.551237 -0.787244 0.276377
+    outer loop
+      vertex -3.37346 -0.627506 7.14715
+      vertex -3.49042 -0.709406 7.14715
+      vertex -3.31744 -0.694272 6.84524
+    endloop
+  endfacet
+  facet normal 0.679561 -0.679568 0.276377
+    outer loop
+      vertex -3.27249 -0.526541 7.14715
+      vertex -3.37346 -0.627506 7.14715
+      vertex -3.31744 -0.694272 6.84524
+    endloop
+  endfacet
+  facet normal 0.81601 0.571378 -0.0874889
+    outer loop
+      vertex -3.03727 0.498096 5.82569
+      vertex -3.16006 0.620885 5.48236
+      vertex -3.13687 0.640341 5.82569
+    endloop
+  endfacet
+  facet normal 0.819151 0.573577 0
+    outer loop
+      vertex -3.03727 0.498096 6.17431
+      vertex -3.13687 0.640341 5.82569
+      vertex -3.13687 0.640341 6.17431
+    endloop
+  endfacet
+  facet normal 0.819151 0.573577 0
+    outer loop
+      vertex -3.13687 0.640341 5.82569
+      vertex -3.03727 0.498096 6.17431
+      vertex -3.03727 0.498096 5.82569
+    endloop
+  endfacet
+  facet normal 0.406156 -0.871007 0.276376
+    outer loop
+      vertex -3.5 -0.780235 6.93801
+      vertex -3.5 -0.809671 6.84524
+      vertex -3.44685 -0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.75428 0.0659876 -0.653229
+    outer loop
+      vertex -3.47738 0 4.18738
+      vertex -3.4838 0.0733862 4.18738
+      vertex -3.32642 0 4.3617
+    endloop
+  endfacet
+  facet normal 0.75428 -0.0659876 -0.653229
+    outer loop
+      vertex -3.32642 0 4.3617
+      vertex -3.4838 -0.0733862 4.18738
+      vertex -3.47738 0 4.18738
+    endloop
+  endfacet
+  facet normal 0.704397 0.493221 -0.510449
+    outer loop
+      vertex -3.40327 0.286788 4.3617
+      vertex -3.46061 0.368688 4.3617
+      vertex -3.35832 0.454519 4.58579
+    endloop
+  endfacet
+  facet normal 0.919144 -0.0804123 -0.385626
+    outer loop
+      vertex -3.08085 0 4.85285
+      vertex -3.20364 -0.122787 4.58579
+      vertex -3.19289 0 4.58579
+    endloop
+  endfacet
+  facet normal 0.856637 -0.0749438 -0.510447
+    outer loop
+      vertex -3.20364 -0.122787 4.58579
+      vertex -3.32642 0 4.3617
+      vertex -3.19289 0 4.58579
+    endloop
+  endfacet
+  facet normal 0.830607 -0.222559 -0.510451
+    outer loop
+      vertex -3.20364 -0.122787 4.58579
+      vertex -3.36101 -0.196175 4.3617
+      vertex -3.33514 -0.0995998 4.3617
+    endloop
+  endfacet
+  facet normal 0.731364 -0.195967 -0.653226
+    outer loop
+      vertex -3.36101 -0.196175 4.3617
+      vertex -3.4838 -0.0733862 4.18738
+      vertex -3.33514 -0.0995998 4.3617
+    endloop
+  endfacet
+  facet normal 0.704398 -0.49322 -0.510449
+    outer loop
+      vertex -3.35832 -0.454519 4.58579
+      vertex -3.40327 -0.286788 4.3617
+      vertex -3.28763 -0.353553 4.58579
+    endloop
+  endfacet
+  facet normal 0.779341 -0.363413 -0.510449
+    outer loop
+      vertex -3.28763 -0.353553 4.58579
+      vertex -3.40327 -0.286788 4.3617
+      vertex -3.23554 -0.241844 4.58579
+    endloop
+  endfacet
+  facet normal 0.569893 -0.152704 -0.807406
+    outer loop
+      vertex -3.4838 -0.0733862 4.18738
+      vertex -3.5 -0.133838 4.18738
+      vertex -3.5 -0.0748034 4.17622
+    endloop
+  endfacet
+  facet normal 0.686224 -0.319986 -0.653227
+    outer loop
+      vertex -3.36101 -0.196175 4.3617
+      vertex -3.5 -0.208334 4.22165
+      vertex -3.5 -0.145588 4.19091
+    endloop
+  endfacet
+  facet normal 0.406154 -0.871008 0.276376
+    outer loop
+      vertex -3.5 -0.780235 6.93801
+      vertex -3.49042 -0.709406 7.14715
+      vertex -3.5 -0.713872 7.14715
+    endloop
+  endfacet
+  facet normal 0.406156 -0.871007 0.276376
+    outer loop
+      vertex -3.49042 -0.709406 7.14715
+      vertex -3.5 -0.780235 6.93801
+      vertex -3.44685 -0.784885 6.84524
+    endloop
+  endfacet
+  facet normal 0.389929 -0.836212 0.385624
+    outer loop
+      vertex -3.5 -0.692819 7.1928
+      vertex -3.5 -0.713872 7.14715
+      vertex -3.49042 -0.709406 7.14715
+    endloop
+  endfacet
+  facet normal 0.652412 -0.652419 0.385627
+    outer loop
+      vertex -3.35832 -0.454519 7.41421
+      vertex -3.44548 -0.541675 7.41421
+      vertex -3.37346 -0.627506 7.14715
+    endloop
+  endfacet
+  facet normal 0.529218 -0.755792 0.385626
+    outer loop
+      vertex -3.5 -0.616436 7.34251
+      vertex -3.44548 -0.541675 7.41421
+      vertex -3.5 -0.57985 7.41421
+    endloop
+  endfacet
+  facet normal 0.529217 -0.755792 0.385626
+    outer loop
+      vertex -3.44548 -0.541675 7.41421
+      vertex -3.5 -0.616436 7.34251
+      vertex -3.37346 -0.627506 7.14715
+    endloop
+  endfacet
+  facet normal 0.816012 0.571375 -0.0874904
+    outer loop
+      vertex -3.06348 0.482963 5.48236
+      vertex -3.16006 0.620885 5.48236
+      vertex -3.03727 0.498096 5.82569
+    endloop
+  endfacet
+  facet normal 0.902831 0.421 -0.0874906
+    outer loop
+      vertex -2.96388 0.340718 5.82569
+      vertex -3.06348 0.482963 5.48236
+      vertex -3.03727 0.498096 5.82569
+    endloop
+  endfacet
+  facet normal 0.891217 0.238799 -0.385625
+    outer loop
+      vertex -3.09329 0.142243 4.85285
+      vertex -3.20364 0.122787 4.58579
+      vertex -3.13025 0.280166 4.85285
+    endloop
+  endfacet
+  facet normal 0.608043 0.60805 -0.510449
+    outer loop
+      vertex -3.35832 0.454519 4.58579
+      vertex -3.46061 0.368688 4.3617
+      vertex -3.44548 0.541675 4.58579
+    endloop
+  endfacet
+  facet normal 0.755797 0.52921 -0.385627
+    outer loop
+      vertex -3.28763 0.353553 4.58579
+      vertex -3.35832 0.454519 4.58579
+      vertex -3.19059 0.409575 4.85285
+    endloop
+  endfacet
+  facet normal 0.731364 0.195967 -0.653226
+    outer loop
+      vertex -3.33514 0.0995998 4.3617
+      vertex -3.4838 0.0733862 4.18738
+      vertex -3.36101 0.196175 4.3617
+    endloop
+  endfacet
+  facet normal 0.569892 0.152708 -0.807405
+    outer loop
+      vertex -3.4838 0.0733862 4.18738
+      vertex -3.5 0.07053 4.17541
+      vertex -3.5 0.0748034 4.17622
+    endloop
+  endfacet
+  facet normal 0.587756 0.0513921 -0.807404
+    outer loop
+      vertex -3.4838 0.0733862 4.18738
+      vertex -3.5 0.0658329 4.17511
+      vertex -3.5 0.07053 4.17541
+    endloop
+  endfacet
+  facet normal 0.535386 0.535405 -0.653225
+    outer loop
+      vertex -3.46061 0.368688 4.3617
+      vertex -3.5 0.335639 4.30233
+      vertex -3.5 0.358134 4.32076
+    endloop
+  endfacet
+  facet normal 0.569892 -0.152708 -0.807405
+    outer loop
+      vertex -3.4838 -0.0733862 4.18738
+      vertex -3.5 -0.0748034 4.17622
+      vertex -3.5 -0.07053 4.17541
+    endloop
+  endfacet
+  facet normal 0.535391 0.535398 -0.653228
+    outer loop
+      vertex -3.46061 0.368688 4.3617
+      vertex -3.5 0.358134 4.32076
+      vertex -3.5 0.408073 4.3617
+    endloop
+  endfacet
+  facet normal 0.871007 0.406157 -0.276376
+    outer loop
+      vertex -3.13025 0.280166 4.85285
+      vertex -3.19059 0.409575 4.85285
+      vertex -3.04835 0.309975 5.15476
+    endloop
+  endfacet
+  facet normal 0.928303 0.248736 -0.276376
+    outer loop
+      vertex -3.00746 0.157378 5.15476
+      vertex -3.13025 0.280166 4.85285
+      vertex -3.04835 0.309975 5.15476
+    endloop
+  endfacet
+  facet normal 0.620231 0.43429 -0.653227
+    outer loop
+      vertex -3.40327 0.286788 4.3617
+      vertex -3.5 0.230939 4.23272
+      vertex -3.5 0.278325 4.26422
+    endloop
+  endfacet
+  facet normal 0.836209 0.38993 -0.385627
+    outer loop
+      vertex -3.13025 0.280166 4.85285
+      vertex -3.23554 0.241844 4.58579
+      vertex -3.19059 0.409575 4.85285
+    endloop
+  endfacet
+  facet normal 0.919144 0.0804135 -0.385626
+    outer loop
+      vertex -3.08085 0 4.85285
+      vertex -3.20364 0.122787 4.58579
+      vertex -3.09329 0.142243 4.85285
+    endloop
+  endfacet
+  facet normal 0.686224 0.319986 -0.653227
+    outer loop
+      vertex -3.36101 0.196175 4.3617
+      vertex -3.5 0.145588 4.19091
+      vertex -3.5 0.208334 4.22165
+    endloop
+  endfacet
+  facet normal 0.731358 0.195984 -0.653228
+    outer loop
+      vertex -3.36101 0.196175 4.3617
+      vertex -3.5 0.133838 4.18738
+      vertex -3.5 0.145588 4.19091
+    endloop
+  endfacet
+  facet normal 0.731362 0.19597 -0.653227
+    outer loop
+      vertex -3.5 0.133838 4.18738
+      vertex -3.36101 0.196175 4.3617
+      vertex -3.4838 0.0733862 4.18738
+    endloop
+  endfacet
+  facet normal 0.919144 0.0804123 -0.385626
+    outer loop
+      vertex -3.19289 0 4.58579
+      vertex -3.20364 0.122787 4.58579
+      vertex -3.08085 0 4.85285
+    endloop
+  endfacet
+  facet normal 0.856637 0.0749438 -0.510447
+    outer loop
+      vertex -3.19289 0 4.58579
+      vertex -3.32642 0 4.3617
+      vertex -3.20364 0.122787 4.58579
+    endloop
+  endfacet
+  facet normal 0.891216 0.238802 -0.385627
+    outer loop
+      vertex -3.20364 0.122787 4.58579
+      vertex -3.23554 0.241844 4.58579
+      vertex -3.13025 0.280166 4.85285
+    endloop
+  endfacet
+  facet normal 0.755796 0.529212 -0.385626
+    outer loop
+      vertex -3.19059 0.409575 4.85285
+      vertex -3.35832 0.454519 4.58579
+      vertex -3.27249 0.526541 4.85285
+    endloop
+  endfacet
+  facet normal 0.587756 -0.0513921 -0.807404
+    outer loop
+      vertex -3.4838 -0.0733862 4.18738
+      vertex -3.5 -0.07053 4.17541
+      vertex -3.5 -0.0658329 4.17511
+    endloop
+  endfacet
+  facet normal 0.830607 0.222562 -0.51045
+    outer loop
+      vertex -3.20364 0.122787 4.58579
+      vertex -3.36101 0.196175 4.3617
+      vertex -3.23554 0.241844 4.58579
+    endloop
+  endfacet
+  facet normal 0.779342 0.363411 -0.510449
+    outer loop
+      vertex -3.36101 0.196175 4.3617
+      vertex -3.40327 0.286788 4.3617
+      vertex -3.23554 0.241844 4.58579
+    endloop
+  endfacet
+  facet normal 0.836209 0.389931 -0.385627
+    outer loop
+      vertex -3.23554 0.241844 4.58579
+      vertex -3.28763 0.353553 4.58579
+      vertex -3.19059 0.409575 4.85285
+    endloop
+  endfacet
+  facet normal 0.779341 0.363413 -0.510449
+    outer loop
+      vertex -3.23554 0.241844 4.58579
+      vertex -3.40327 0.286788 4.3617
+      vertex -3.28763 0.353553 4.58579
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -22.5 -13 0
+      vertex -22.5 13 2
+      vertex -22.5 13 0
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -22.5 13 2
+      vertex -22.5 -13 0
+      vertex -22.5 -13 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -10.5 0 2
+      vertex -5.5 -13 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -10.5304 0.347296 2
+      vertex -10.5 0 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -10.6206 0.68404 2
+      vertex -10.5304 0.347296 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -10.768 0.999999 2
+      vertex -10.6206 0.68404 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -10.9679 1.28557 2
+      vertex -10.768 0.999999 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -11.2144 1.53209 2
+      vertex -10.9679 1.28557 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -11.5 1.73205 2
+      vertex -11.2144 1.53209 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -11.816 1.87938 2
+      vertex -11.5 1.73205 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -12.1527 1.96961 2
+      vertex -11.816 1.87938 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -12.5 2 2
+      vertex -12.1527 1.96961 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 13 2
+      vertex -12.8473 1.96961 2
+      vertex -12.5 2 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -22.5 13 2
+      vertex -12.8473 1.96961 2
+      vertex -5.5 13 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8473 1.96961 2
+      vertex -22.5 13 2
+      vertex -13.184 1.87938 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.184 1.87938 2
+      vertex -22.5 13 2
+      vertex -13.5 1.73205 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.5 1.73205 2
+      vertex -22.5 13 2
+      vertex -13.7856 1.53209 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4696 0.347296 2
+      vertex -22.5 13 2
+      vertex -14.5 0 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3794 0.68404 2
+      vertex -22.5 13 2
+      vertex -14.4696 0.347296 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.232 1 2
+      vertex -22.5 13 2
+      vertex -14.3794 0.68404 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.0321 1.28557 2
+      vertex -22.5 13 2
+      vertex -14.232 1 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -13.7856 1.53209 2
+      vertex -22.5 13 2
+      vertex -14.0321 1.28557 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.5304 -0.347296 2
+      vertex -5.5 -13 2
+      vertex -10.5 0 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.6206 -0.68404 2
+      vertex -5.5 -13 2
+      vertex -10.5304 -0.347296 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.768 -0.999999 2
+      vertex -5.5 -13 2
+      vertex -10.6206 -0.68404 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10.9679 -1.28557 2
+      vertex -5.5 -13 2
+      vertex -10.768 -0.999999 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.2144 -1.53209 2
+      vertex -5.5 -13 2
+      vertex -10.9679 -1.28557 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.5 -1.73205 2
+      vertex -5.5 -13 2
+      vertex -11.2144 -1.53209 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -11.816 -1.87938 2
+      vertex -5.5 -13 2
+      vertex -11.5 -1.73205 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.1527 -1.96961 2
+      vertex -5.5 -13 2
+      vertex -11.816 -1.87938 2
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -12.5 -2 2
+      vertex -5.5 -13 2
+      vertex -12.1527 -1.96961 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8473 -1.96961 2
+      vertex -5.5 -13 2
+      vertex -12.5 -2 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5 -13 2
+      vertex -12.8473 -1.96961 2
+      vertex -13.184 -1.87938 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5 -13 2
+      vertex -13.184 -1.87938 2
+      vertex -13.5 -1.73205 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5 -13 2
+      vertex -13.5 -1.73205 2
+      vertex -13.7856 -1.53209 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5 -13 2
+      vertex -13.7856 -1.53209 2
+      vertex -14.0321 -1.28557 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -22.5 -13 2
+      vertex -14.5 0 2
+      vertex -22.5 13 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.5 0 2
+      vertex -22.5 -13 2
+      vertex -14.4696 -0.347296 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.4696 -0.347296 2
+      vertex -22.5 -13 2
+      vertex -14.3794 -0.68404 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -12.8473 -1.96961 2
+      vertex -22.5 -13 2
+      vertex -5.5 -13 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.232 -1 2
+      vertex -22.5 -13 2
+      vertex -14.0321 -1.28557 2
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.3794 -0.68404 2
+      vertex -22.5 -13 2
+      vertex -14.232 -1 2
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.5 -13 0
+      vertex 1.5 -11 0
+      vertex 5.5 13 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 5.5 -13 0
+      vertex -3.5 -11 0
+      vertex 1.5 -11 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -10.5 0 0
+      vertex -3.5 11 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -10.5304 -0.347296 0
+      vertex -10.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -10.6206 -0.68404 0
+      vertex -10.5304 -0.347296 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -10.768 -0.999999 0
+      vertex -10.6206 -0.68404 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -10.9679 -1.28557 0
+      vertex -10.768 -0.999999 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -11.2144 -1.53209 0
+      vertex -10.9679 -1.28557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -11.5 -1.73205 0
+      vertex -11.2144 -1.53209 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -11.816 -1.87938 0
+      vertex -11.5 -1.73205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -12.1527 -1.96961 0
+      vertex -11.816 -1.87938 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 -11 0
+      vertex -12.5 -2 0
+      vertex -12.1527 -1.96961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5 -13 0
+      vertex -12.5 -2 0
+      vertex -3.5 -11 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.5 -2 0
+      vertex -22.5 -13 0
+      vertex -12.8473 -1.96961 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.8473 -1.96961 0
+      vertex -22.5 -13 0
+      vertex -13.184 -1.87938 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.184 -1.87938 0
+      vertex -22.5 -13 0
+      vertex -13.5 -1.73205 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.4696 -0.347296 0
+      vertex -22.5 -13 0
+      vertex -14.5 0 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.3794 -0.68404 0
+      vertex -22.5 -13 0
+      vertex -14.4696 -0.347296 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.232 -1 0
+      vertex -22.5 -13 0
+      vertex -14.3794 -0.68404 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -14.0321 -1.28557 0
+      vertex -22.5 -13 0
+      vertex -14.232 -1 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.7856 -1.53209 0
+      vertex -22.5 -13 0
+      vertex -14.0321 -1.28557 0
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.5 -1.73205 0
+      vertex -22.5 -13 0
+      vertex -13.7856 -1.53209 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5 -13 0
+      vertex -3.5 -11 0
+      vertex 5.5 -13 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.5 11 0
+      vertex 5.5 13 0
+      vertex 1.5 -11 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 11 0
+      vertex 5.5 13 0
+      vertex 1.5 11 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.5304 0.347296 0
+      vertex -3.5 11 0
+      vertex -10.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.6206 0.68404 0
+      vertex -3.5 11 0
+      vertex -10.5304 0.347296 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.768 0.999999 0
+      vertex -3.5 11 0
+      vertex -10.6206 0.68404 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.9679 1.28557 0
+      vertex -3.5 11 0
+      vertex -10.768 0.999999 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.2144 1.53209 0
+      vertex -3.5 11 0
+      vertex -10.9679 1.28557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.5 1.73205 0
+      vertex -3.5 11 0
+      vertex -11.2144 1.53209 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.816 1.87938 0
+      vertex -3.5 11 0
+      vertex -11.5 1.73205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.1527 1.96961 0
+      vertex -3.5 11 0
+      vertex -11.816 1.87938 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5 2 0
+      vertex -3.5 11 0
+      vertex -12.1527 1.96961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5 13 0
+      vertex -12.5 2 0
+      vertex -12.8473 1.96961 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5 13 0
+      vertex -12.8473 1.96961 0
+      vertex -13.184 1.87938 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5 13 0
+      vertex -13.184 1.87938 0
+      vertex -13.5 1.73205 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5 13 0
+      vertex -13.5 1.73205 0
+      vertex -13.7856 1.53209 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5 13 0
+      vertex -14.5 0 0
+      vertex -22.5 -13 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.5 0 0
+      vertex -22.5 13 0
+      vertex -14.4696 0.347296 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.4696 0.347296 0
+      vertex -22.5 13 0
+      vertex -14.3794 0.68404 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.5 11 0
+      vertex -22.5 13 0
+      vertex 5.5 13 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5 2 0
+      vertex -22.5 13 0
+      vertex -3.5 11 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.0321 1.28557 0
+      vertex -22.5 13 0
+      vertex -13.7856 1.53209 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.232 1 0
+      vertex -22.5 13 0
+      vertex -14.0321 1.28557 0
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.3794 0.68404 0
+      vertex -22.5 13 0
+      vertex -14.232 1 0
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -22.5 -13 2
+      vertex -22.5 -13 0
+      vertex -5.5 -13 2
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.5 -13 2
+      vertex 5.5 -13 10
+      vertex -5.5 -13 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -5.5 -13 2
+      vertex 5.5 -13 0
+      vertex 5.5 -13 10
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 5.5 -13 0
+      vertex -5.5 -13 2
+      vertex -22.5 -13 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 5.5 13 10
+      vertex -5.5 13 2
+      vertex -5.5 13 10
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 5.5 13 0
+      vertex -5.5 13 2
+      vertex 5.5 13 10
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -22.5 13 0
+      vertex -5.5 13 2
+      vertex 5.5 13 0
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.5 13 2
+      vertex -22.5 13 0
+      vertex -22.5 13 2
+    endloop
+  endfacet
+  facet normal -0.573576 -0.819152 0
+    outer loop
+      vertex -11.5 1.73205 0
+      vertex -11.2144 1.53209 2
+      vertex -11.5 1.73205 2
+    endloop
+  endfacet
+  facet normal -0.573576 -0.819152 -0
+    outer loop
+      vertex -11.2144 1.53209 2
+      vertex -11.5 1.73205 0
+      vertex -11.2144 1.53209 0
+    endloop
+  endfacet
+  facet normal 0.258818 0.965926 -0
+    outer loop
+      vertex -12.8473 -1.96961 0
+      vertex -13.184 -1.87938 2
+      vertex -12.8473 -1.96961 2
+    endloop
+  endfacet
+  facet normal 0.258818 0.965926 0
+    outer loop
+      vertex -13.184 -1.87938 2
+      vertex -12.8473 -1.96961 0
+      vertex -13.184 -1.87938 0
+    endloop
+  endfacet
+  facet normal 0.258818 -0.965926 0
+    outer loop
+      vertex -13.184 1.87938 0
+      vertex -12.8473 1.96961 2
+      vertex -13.184 1.87938 2
+    endloop
+  endfacet
+  facet normal 0.258818 -0.965926 0
+    outer loop
+      vertex -12.8473 1.96961 2
+      vertex -13.184 1.87938 0
+      vertex -12.8473 1.96961 0
+    endloop
+  endfacet
+  facet normal 0.906307 -0.422619 0
+    outer loop
+      vertex -14.3794 0.68404 2
+      vertex -14.232 1 0
+      vertex -14.232 1 2
+    endloop
+  endfacet
+  facet normal 0.906307 -0.422619 0
+    outer loop
+      vertex -14.232 1 0
+      vertex -14.3794 0.68404 2
+      vertex -14.3794 0.68404 0
+    endloop
+  endfacet
+  facet normal 0.422619 0.906307 -0
+    outer loop
+      vertex -13.184 -1.87938 0
+      vertex -13.5 -1.73205 2
+      vertex -13.184 -1.87938 2
+    endloop
+  endfacet
+  facet normal 0.422619 0.906307 0
+    outer loop
+      vertex -13.5 -1.73205 2
+      vertex -13.184 -1.87938 0
+      vertex -13.5 -1.73205 0
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258818 0
+    outer loop
+      vertex -10.5304 0.347296 0
+      vertex -10.6206 0.68404 2
+      vertex -10.6206 0.68404 0
+    endloop
+  endfacet
+  facet normal -0.965926 -0.258818 0
+    outer loop
+      vertex -10.6206 0.68404 2
+      vertex -10.5304 0.347296 0
+      vertex -10.5304 0.347296 2
+    endloop
+  endfacet
+  facet normal -0.906307 -0.422621 0
+    outer loop
+      vertex -10.6206 0.68404 0
+      vertex -10.768 0.999999 2
+      vertex -10.768 0.999999 0
+    endloop
+  endfacet
+  facet normal -0.906307 -0.422621 0
+    outer loop
+      vertex -10.768 0.999999 2
+      vertex -10.6206 0.68404 0
+      vertex -10.6206 0.68404 2
+    endloop
+  endfacet
+  facet normal -0.819153 -0.573575 0
+    outer loop
+      vertex -10.768 0.999999 0
+      vertex -10.9679 1.28557 2
+      vertex -10.9679 1.28557 0
+    endloop
+  endfacet
+  facet normal -0.819153 -0.573575 0
+    outer loop
+      vertex -10.9679 1.28557 2
+      vertex -10.768 0.999999 0
+      vertex -10.768 0.999999 2
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -10.9679 1.28557 0
+      vertex -11.2144 1.53209 2
+      vertex -11.2144 1.53209 0
+    endloop
+  endfacet
+  facet normal -0.707107 -0.707107 0
+    outer loop
+      vertex -11.2144 1.53209 2
+      vertex -10.9679 1.28557 0
+      vertex -10.9679 1.28557 2
+    endloop
+  endfacet
+  facet normal -0.422619 -0.906307 0
+    outer loop
+      vertex -11.816 1.87938 0
+      vertex -11.5 1.73205 2
+      vertex -11.816 1.87938 2
+    endloop
+  endfacet
+  facet normal -0.422619 -0.906307 -0
+    outer loop
+      vertex -11.5 1.73205 2
+      vertex -11.816 1.87938 0
+      vertex -11.5 1.73205 0
+    endloop
+  endfacet
+  facet normal -0.0871574 -0.996195 0
+    outer loop
+      vertex -12.5 2 0
+      vertex -12.1527 1.96961 2
+      vertex -12.5 2 2
+    endloop
+  endfacet
+  facet normal -0.0871574 -0.996195 -0
+    outer loop
+      vertex -12.1527 1.96961 2
+      vertex -12.5 2 0
+      vertex -12.1527 1.96961 0
+    endloop
+  endfacet
+  facet normal -0.258818 -0.965926 0
+    outer loop
+      vertex -12.1527 1.96961 0
+      vertex -11.816 1.87938 2
+      vertex -12.1527 1.96961 2
+    endloop
+  endfacet
+  facet normal -0.258818 -0.965926 -0
+    outer loop
+      vertex -11.816 1.87938 2
+      vertex -12.1527 1.96961 0
+      vertex -11.816 1.87938 0
+    endloop
+  endfacet
+  facet normal 0.996195 -0.0871574 0
+    outer loop
+      vertex -14.5 0 2
+      vertex -14.4696 0.347296 0
+      vertex -14.4696 0.347296 2
+    endloop
+  endfacet
+  facet normal 0.996195 -0.0871574 0
+    outer loop
+      vertex -14.4696 0.347296 0
+      vertex -14.5 0 2
+      vertex -14.5 0 0
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex -14.0321 1.28557 2
+      vertex -13.7856 1.53209 0
+      vertex -13.7856 1.53209 2
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex -13.7856 1.53209 0
+      vertex -14.0321 1.28557 2
+      vertex -14.0321 1.28557 0
+    endloop
+  endfacet
+  facet normal 0.422621 -0.906307 0
+    outer loop
+      vertex -13.5 1.73205 0
+      vertex -13.184 1.87938 2
+      vertex -13.5 1.73205 2
+    endloop
+  endfacet
+  facet normal 0.422621 -0.906307 0
+    outer loop
+      vertex -13.184 1.87938 2
+      vertex -13.5 1.73205 0
+      vertex -13.184 1.87938 0
+    endloop
+  endfacet
+  facet normal 0.0871574 -0.996195 0
+    outer loop
+      vertex -12.8473 1.96961 0
+      vertex -12.5 2 2
+      vertex -12.8473 1.96961 2
+    endloop
+  endfacet
+  facet normal 0.0871574 -0.996195 0
+    outer loop
+      vertex -12.5 2 2
+      vertex -12.8473 1.96961 0
+      vertex -12.5 2 0
+    endloop
+  endfacet
+  facet normal 0.573575 -0.819153 0
+    outer loop
+      vertex -13.7856 1.53209 0
+      vertex -13.5 1.73205 2
+      vertex -13.7856 1.53209 2
+    endloop
+  endfacet
+  facet normal 0.573575 -0.819153 0
+    outer loop
+      vertex -13.5 1.73205 2
+      vertex -13.7856 1.53209 0
+      vertex -13.5 1.73205 0
+    endloop
+  endfacet
+  facet normal -0.996195 -0.0871574 0
+    outer loop
+      vertex -10.5 0 0
+      vertex -10.5304 0.347296 2
+      vertex -10.5304 0.347296 0
+    endloop
+  endfacet
+  facet normal -0.996195 -0.0871574 0
+    outer loop
+      vertex -10.5304 0.347296 2
+      vertex -10.5 0 0
+      vertex -10.5 0 2
+    endloop
+  endfacet
+  facet normal -0.0871574 0.996195 0
+    outer loop
+      vertex -12.1527 -1.96961 0
+      vertex -12.5 -2 2
+      vertex -12.1527 -1.96961 2
+    endloop
+  endfacet
+  facet normal -0.0871574 0.996195 0
+    outer loop
+      vertex -12.5 -2 2
+      vertex -12.1527 -1.96961 0
+      vertex -12.5 -2 0
+    endloop
+  endfacet
+  facet normal -0.258818 0.965926 0
+    outer loop
+      vertex -11.816 -1.87938 0
+      vertex -12.1527 -1.96961 2
+      vertex -11.816 -1.87938 2
+    endloop
+  endfacet
+  facet normal -0.258818 0.965926 0
+    outer loop
+      vertex -12.1527 -1.96961 2
+      vertex -11.816 -1.87938 0
+      vertex -12.1527 -1.96961 0
+    endloop
+  endfacet
+  facet normal -0.819153 0.573575 0
+    outer loop
+      vertex -10.9679 -1.28557 0
+      vertex -10.768 -0.999999 2
+      vertex -10.768 -0.999999 0
+    endloop
+  endfacet
+  facet normal -0.819153 0.573575 0
+    outer loop
+      vertex -10.768 -0.999999 2
+      vertex -10.9679 -1.28557 0
+      vertex -10.9679 -1.28557 2
+    endloop
+  endfacet
+  facet normal 0.0871574 0.996195 -0
+    outer loop
+      vertex -12.5 -2 0
+      vertex -12.8473 -1.96961 2
+      vertex -12.5 -2 2
+    endloop
+  endfacet
+  facet normal 0.0871574 0.996195 0
+    outer loop
+      vertex -12.8473 -1.96961 2
+      vertex -12.5 -2 0
+      vertex -12.8473 -1.96961 0
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex -13.7856 -1.53209 2
+      vertex -14.0321 -1.28557 0
+      vertex -14.0321 -1.28557 2
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex -14.0321 -1.28557 0
+      vertex -13.7856 -1.53209 2
+      vertex -13.7856 -1.53209 0
+    endloop
+  endfacet
+  facet normal 0.906307 0.422619 0
+    outer loop
+      vertex -14.232 -1 2
+      vertex -14.3794 -0.68404 0
+      vertex -14.3794 -0.68404 2
+    endloop
+  endfacet
+  facet normal 0.906307 0.422619 0
+    outer loop
+      vertex -14.3794 -0.68404 0
+      vertex -14.232 -1 2
+      vertex -14.232 -1 0
+    endloop
+  endfacet
+  facet normal 0.996195 0.0871574 0
+    outer loop
+      vertex -14.4696 -0.347296 2
+      vertex -14.5 0 0
+      vertex -14.5 0 2
+    endloop
+  endfacet
+  facet normal 0.996195 0.0871574 0
+    outer loop
+      vertex -14.5 0 0
+      vertex -14.4696 -0.347296 2
+      vertex -14.4696 -0.347296 0
+    endloop
+  endfacet
+  facet normal 0.965926 -0.258818 0
+    outer loop
+      vertex -14.4696 0.347296 2
+      vertex -14.3794 0.68404 0
+      vertex -14.3794 0.68404 2
+    endloop
+  endfacet
+  facet normal 0.965926 -0.258818 0
+    outer loop
+      vertex -14.3794 0.68404 0
+      vertex -14.4696 0.347296 2
+      vertex -14.4696 0.347296 0
+    endloop
+  endfacet
+  facet normal 0.819152 -0.573576 0
+    outer loop
+      vertex -14.232 1 2
+      vertex -14.0321 1.28557 0
+      vertex -14.0321 1.28557 2
+    endloop
+  endfacet
+  facet normal 0.819152 -0.573576 0
+    outer loop
+      vertex -14.0321 1.28557 0
+      vertex -14.232 1 2
+      vertex -14.232 1 0
+    endloop
+  endfacet
+  facet normal -0.965926 0.258818 0
+    outer loop
+      vertex -10.6206 -0.68404 0
+      vertex -10.5304 -0.347296 2
+      vertex -10.5304 -0.347296 0
+    endloop
+  endfacet
+  facet normal -0.965926 0.258818 0
+    outer loop
+      vertex -10.5304 -0.347296 2
+      vertex -10.6206 -0.68404 0
+      vertex -10.6206 -0.68404 2
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -11.2144 -1.53209 0
+      vertex -10.9679 -1.28557 2
+      vertex -10.9679 -1.28557 0
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -10.9679 -1.28557 2
+      vertex -11.2144 -1.53209 0
+      vertex -11.2144 -1.53209 2
+    endloop
+  endfacet
+  facet normal -0.422621 0.906307 0
+    outer loop
+      vertex -11.5 -1.73205 0
+      vertex -11.816 -1.87938 2
+      vertex -11.5 -1.73205 2
+    endloop
+  endfacet
+  facet normal -0.422621 0.906307 0
+    outer loop
+      vertex -11.816 -1.87938 2
+      vertex -11.5 -1.73205 0
+      vertex -11.816 -1.87938 0
+    endloop
+  endfacet
+  facet normal -0.906307 0.422621 0
+    outer loop
+      vertex -10.768 -0.999999 0
+      vertex -10.6206 -0.68404 2
+      vertex -10.6206 -0.68404 0
+    endloop
+  endfacet
+  facet normal -0.906307 0.422621 0
+    outer loop
+      vertex -10.6206 -0.68404 2
+      vertex -10.768 -0.999999 0
+      vertex -10.768 -0.999999 2
+    endloop
+  endfacet
+  facet normal 0.573576 0.819152 -0
+    outer loop
+      vertex -13.5 -1.73205 0
+      vertex -13.7856 -1.53209 2
+      vertex -13.5 -1.73205 2
+    endloop
+  endfacet
+  facet normal 0.573576 0.819152 0
+    outer loop
+      vertex -13.7856 -1.53209 2
+      vertex -13.5 -1.73205 0
+      vertex -13.7856 -1.53209 0
+    endloop
+  endfacet
+  facet normal 0.965926 0.258818 0
+    outer loop
+      vertex -14.3794 -0.68404 2
+      vertex -14.4696 -0.347296 0
+      vertex -14.4696 -0.347296 2
+    endloop
+  endfacet
+  facet normal 0.965926 0.258818 0
+    outer loop
+      vertex -14.4696 -0.347296 0
+      vertex -14.3794 -0.68404 2
+      vertex -14.3794 -0.68404 0
+    endloop
+  endfacet
+  facet normal 0.819152 0.573576 0
+    outer loop
+      vertex -14.0321 -1.28557 2
+      vertex -14.232 -1 0
+      vertex -14.232 -1 2
+    endloop
+  endfacet
+  facet normal 0.819152 0.573576 0
+    outer loop
+      vertex -14.232 -1 0
+      vertex -14.0321 -1.28557 2
+      vertex -14.0321 -1.28557 0
+    endloop
+  endfacet
+  facet normal -0.996195 0.0871574 0
+    outer loop
+      vertex -10.5304 -0.347296 0
+      vertex -10.5 0 2
+      vertex -10.5 0 0
+    endloop
+  endfacet
+  facet normal -0.996195 0.0871574 0
+    outer loop
+      vertex -10.5 0 2
+      vertex -10.5304 -0.347296 0
+      vertex -10.5304 -0.347296 2
+    endloop
+  endfacet
+  facet normal -0.573575 0.819153 0
+    outer loop
+      vertex -11.2144 -1.53209 0
+      vertex -11.5 -1.73205 2
+      vertex -11.2144 -1.53209 2
+    endloop
+  endfacet
+  facet normal -0.573575 0.819153 0
+    outer loop
+      vertex -11.5 -1.73205 2
+      vertex -11.2144 -1.53209 0
+      vertex -11.5 -1.73205 0
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -5.5 -13 2
+      vertex -5.5 13 10
+      vertex -5.5 13 2
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -5.5 13 10
+      vertex -5.5 -13 2
+      vertex -5.5 -13 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.5 13 10
+      vertex 3.5 11 10
+      vertex 5.5 -13 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.5 13 10
+      vertex -3.5 11 10
+      vertex 3.5 11 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.5 11 10
+      vertex -5.5 13 10
+      vertex -3.5 -11 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -5.5 13 10
+      vertex -3.5 11 10
+      vertex 5.5 13 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 3.5 -11 10
+      vertex 5.5 -13 10
+      vertex 3.5 11 10
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -3.5 -11 10
+      vertex 5.5 -13 10
+      vertex 3.5 -11 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.5 -11 10
+      vertex -5.5 -13 10
+      vertex 5.5 -13 10
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.5 -13 10
+      vertex -3.5 -11 10
+      vertex -5.5 13 10
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 5.5 -13 10
+      vertex 5.5 13 0
+      vertex 5.5 13 10
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 5.5 13 0
+      vertex 5.5 -13 10
+      vertex 5.5 -13 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
Added new Y axis end stop switch holder to bg9/endstop_mount.scad as y_holder_switch() and used to create bg9/y_Endstop_mount.stl

Recommend a 8.5mm hole in the back panel under the endstop holder for switch wire routing
